### PR TITLE
fixes #9252 - use new factories and explicitly use host's provision interface

### DIFF
--- a/app/views/foreman_bootdisk/host.erb
+++ b/app/views/foreman_bootdisk/host.erb
@@ -5,11 +5,13 @@
 # Copy this template to customize it, the original is read-only.
 
 <%
-bootdisk_raise(N_('Host has no IP address defined')) if @host.ip.nil? || @host.ip.empty?
-bootdisk_raise(N_('Host has no subnet defined')) unless @host.subnet
-bootdisk_raise(N_('Host has no domain defined')) unless @host.domain
-bootdisk_raise(N_('Subnet (%s) has no gateway defined'), @host.subnet) if @host.subnet.gateway.nil? || @host.subnet.gateway.empty?
-bootdisk_raise(N_('Subnet (%s) has no primary DNS server defined'), @host.subnet) if @host.subnet.dns_primary.nil? || @host.subnet.dns_primary.empty?
+interface = @host.provision_interface
+bootdisk_raise(N_('Host has no provisioning interface defined')) unless interface
+bootdisk_raise(N_('Host has no IP address defined')) if interface.ip.nil? || interface.ip.empty?
+bootdisk_raise(N_('Host has no subnet defined')) unless interface.subnet
+bootdisk_raise(N_('Host has no domain defined')) unless interface.domain
+bootdisk_raise(N_('Subnet (%s) has no gateway defined'), interface.subnet) if interface.subnet.gateway.nil? || interface.subnet.gateway.empty?
+bootdisk_raise(N_('Subnet (%s) has no primary DNS server defined'), interface.subnet) if interface.subnet.dns_primary.nil? || interface.subnet.dns_primary.empty?
 %>
 
 # loop over net* until the host's MAC matches
@@ -17,7 +19,7 @@ bootdisk_raise(N_('Subnet (%s) has no primary DNS server defined'), @host.subnet
 :net<%= i %>
 isset ${net<%= i -%>/mac} || goto no_nic
 echo net<%= i -%> is a ${net<%= i -%>/chip} with MAC ${net<%= i -%>/mac}
-iseq ${net<%= i -%>/mac} <%= @host.mac -%> || goto net<%= i+1 %>
+iseq ${net<%= i -%>/mac} <%= interface.mac -%> || goto net<%= i+1 %>
 ifopen net<%= i %>
 set idx:int32 <%= i %>
 goto loop_success
@@ -26,14 +28,14 @@ goto loop_success
 :loop_success
 echo Configuring net${idx} for static IP address
 ifopen net${idx}
-set netX/ip <%= @host.ip %>
-set netX/netmask <%= @host.subnet.mask %>
-set netX/gateway <%= @host.subnet.gateway %>
+set netX/ip <%= interface.ip %>
+set netX/netmask <%= interface.subnet.mask %>
+set netX/gateway <%= interface.subnet.gateway %>
 route
 
 # Note, iPXE can only use one DNS server
-set dns <%= @host.subnet.dns_primary %>
-set domain <%= @host.domain.to_s %>
+set dns <%= interface.subnet.dns_primary %>
+set domain <%= interface.domain.to_s %>
 
 # Chainload from Foreman rather than embedding OS info here, so the behaviour
 # is entirely dynamic.
@@ -41,6 +43,6 @@ chain <%= bootdisk_chain_url %>
 exit 0
 
 :no_nic
-echo Cannot find interface with MAC <%= @host.mac %>
+echo Cannot find interface with MAC <%= interface.mac %>
 sleep 30
 exit 1

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -20,7 +20,8 @@ class ActionController::TestCase
   end
 
   def setup_host
+    disable_orchestration
     subnet = FactoryGirl.create(:subnet, :gateway => '10.0.1.254', :dns_primary => '8.8.8.8')
-    @host = FactoryGirl.create(:host, :subnet => subnet)
+    @host = FactoryGirl.create(:host, :managed, :subnet => subnet, :ip => subnet.network.sub(/0$/, '4'))
   end
 end


### PR DESCRIPTION
@ares or @GregSutcliffe, is using the provision_interface explicitly here a good idea?  The job of this iPXE script is solely to find and configure the interface on which to retrieve the provision/kickstart template from Foreman.

http://ci.theforeman.org/job/test_plugin_pull_request/534/ running.