### PR TITLE
[WIP] Fixes #8146 - Add subnet-level generic image for template proxying

### DIFF
--- a/app/helpers/concerns/foreman_bootdisk/hosts_helper_ext.rb
+++ b/app/helpers/concerns/foreman_bootdisk/hosts_helper_ext.rb
@@ -11,12 +11,22 @@ module ForemanBootdisk::HostsHelperExt
         select_action_button(_('Boot disk'), {},
           display_bootdisk_link_if_authorized(_("Host '%s' image") % @host.name.split('.')[0], {:controller => 'foreman_bootdisk/disks', :action => 'host', :id => @host}, :class=>'btn'),
           display_bootdisk_link_if_authorized(_("Full host '%s' image") % @host.name.split('.')[0], {:controller => 'foreman_bootdisk/disks', :action => 'full_host', :id => @host}, :class=>'btn'),
+          display_bootdisk_for_subnet,
           display_bootdisk_link_if_authorized(_("Generic image"), {:controller => 'foreman_bootdisk/disks', :action => 'generic'}, :class=>'btn'),
           display_bootdisk_link_if_authorized(_("Help"), {:controller => 'foreman_bootdisk/disks', :action => 'help'}, :class=>'btn')
         )
       )
     )
     host_title_actions_without_bootdisk(*args)
+  end
+
+  # need to wrap this one in a test for template proxy presence
+  def display_bootdisk_for_subnet
+    if (proxy = @host.try(:subnet).try(:tftp)) && proxy.features.map(&:name).include?('Templates')
+      display_bootdisk_link_if_authorized(_("Subnet '%s' image") % @host.subnet.name, {:controller => 'foreman_bootdisk/disks', :action => 'subnet', :id => @host}, :class=>'btn')
+    else
+      ""
+    end
   end
 
   # Core Foreman helpers can't look up a URL against a mounted engine

--- a/app/services/foreman_bootdisk/renderer.rb
+++ b/app/services/foreman_bootdisk/renderer.rb
@@ -5,14 +5,27 @@ module ForemanBootdisk
     include ::Foreman::Renderer
     include Rails.application.routes.url_helpers
 
-    def generic_template_render
+    def generic_template_render(subnet=nil)
       if (Gem::Version.new(SETTINGS[:version].notag) < Gem::Version.new('1.5')) && Setting[:safemode_render]
         raise(::Foreman::Exception.new(N_('Bootdisk is not supported with safemode rendering, please disable safemode_render under Adminster>Settings')))
       end
 
       tmpl = ConfigTemplate.find_by_name(Setting[:bootdisk_generic_host_template]) || raise(::Foreman::Exception.new(N_('Unable to find template specified by %s setting'), 'bootdisk_generic_host_template'))
-      @host = Struct.new(:token, :subnet).new(nil, nil)
-      unattended_render(tmpl.template)
+
+      if subnet.present?
+        # rendering a subnet-level bootdisk requires tricking the renderer into thinking it has a
+        # valid host, with a token, and with a tftp proxy
+        @host = Struct.new(:token, :subnet).new(
+          Struct.new(:value).new('faketoken'),
+          subnet
+        )
+      else
+        @host = Struct.new(:token, :subnet).new(nil,nil)
+      end
+      rtmpl = unattended_render(tmpl.template)
+      # remove the token from subnet-level generation, since this is meant to be generic
+      rtmpl.gsub!(/(?<=iPXE\?)token=faketoken\&(?=mac=)/,'') if @host.present?
+      rtmpl
     end
 
     def bootdisk_chain_url(action = 'iPXE')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ ForemanBootdisk::Engine.routes.draw do
     constraints(:id => /[^\/]+/) do
       get 'hosts/:id', :on => :collection, :to => 'disks#host'
       get 'full_hosts/:id', :on => :collection, :to => 'disks#full_host'
+      get 'subnet/:id', :on => :collection, :to => 'disks#subnet'
     end
   end
 


### PR DESCRIPTION
Posting this for approach-review before working on api/doc stuff

The goal here is to be able to have a copy of the "generic" image, but with the URL replaced with a proxy with the Template feature, so that the network isolation can work. This is clearly only going to work for subnets which can contact that particular proxy.

To achieve this, I've tricked `lib/foreman/renderer.rb` into using the template-proxying codepath by passing in a real Host in build mode. This feels like an acceptable requirement since we need to decide which subnet we're building for (additionally, all the bootdisks are built from the Host page, and all but the 'generic' image require build=true as well). The alternative is a bunch of extra scaffold to add a bootdisk button to the subnet or proxy page, which felt like overkill.

The only nasty bit is having to gsub out the token in the resulting template. Given that's how the core rendered currently works though, I'm not sure how to improve it.

Feedback welcome, and then I can update the api, tests, etc.