### PR TITLE
upd: templates defined for the host are now available on the bootcd

### DIFF
--- a/app/services/foreman_bootdisk/iso_generator.rb
+++ b/app/services/foreman_bootdisk/iso_generator.rb
@@ -17,9 +17,15 @@ class ForemanBootdisk::ISOGenerator
     # aim to convert filenames to something usable under ISO 9660, update the template to match
     # and then still ensure that the fetch() process stores them under the same name
     files = host.operatingsystem.pxe_files(host.medium, host.architecture, host)
+    # add templates
+    host.operatingsystem.config_templates.each do |t|
+      files << {'unattended/template_'.to_sym => "http://#{host.puppetmaster}/unattended/#{t.template_kind}?token=#{host.token}"}
+    end
     files.map! do |bootfile_info|
       bootfile_info.map do |f|
         suffix = f[1].split('/').last
+        # remove query string from the file name
+        suffix = suffix.split(/[?]/).first
         iso_suffix = iso9660_filename(suffix)
         iso_f0 = iso9660_filename(f[0].to_s) + '_' + iso_suffix
         tmpl.gsub!(f[0].to_s + '-' + suffix, iso_f0)


### PR DESCRIPTION
### Suggestion

This makes templates defined for the host (operating system) available on the boot cd and
makes possible (for example) to use kickstart unattended installation via the boot cd

Please consider it like a suggestion. I suppose there are more elegant ways to implement the same.

So what do you think?
