### PR TITLE
fixes #10926 - one click boot off CD for vmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ gPXE images are unsupported due to lack of initrd support.
 ## Configuration
 
 With all image types, hosts have to be registered to Foreman prior to booting
-the image.  Hosts will be identified by their MAC or IP address to provide
+the image by hand. Hosts will be identified by their MAC or IP address to provide
 the correct provisioning template if the host is in build mode.
 
 For per-host images, ensure host IP addresses and subnets are populated, and
@@ -56,6 +56,14 @@ under Infrastructure>Subnets in Foreman.
 
 To permit access to images for non-admin users, add the "Boot disk access" role
 to a user or the "download_bootdisk" permission to an existing role.
+
+## Fully Automated Provisioning
+
+On VMWare compute resources it is possible to create a new host with a cd-drive
+preconfigured and have a per-host image attached before first boot. This allows
+a fully automated provisioning of hosts via ISO boot. This feature can be used by
+selecting the Bootdisk Based provisioning method under the OS tab when creating
+the host, or by setting provision_method: "bootdisk" using the API.
 
 ## Templates
 

--- a/app/assets/javascripts/foreman_bootdisk/host_edit.js
+++ b/app/assets/javascripts/foreman_bootdisk/host_edit.js
@@ -1,0 +1,7 @@
+function bootdisk_provision_method_selected() {
+  $('div[id*=_provisioning]').hide();
+  $('#network_provisioning').show();
+  $('#bootdisk_provisioning').show();
+  $('#image_selection select').attr('disabled', true);
+}
+$(document).on('change', '#host_provision_method_bootdisk', bootdisk_provision_method_selected);

--- a/app/models/concerns/foreman_bootdisk/compute_resources/vmware.rb
+++ b/app/models/concerns/foreman_bootdisk/compute_resources/vmware.rb
@@ -1,0 +1,55 @@
+module ForemanBootdisk
+  module ComputeResources
+    module Vmware
+      extend ActiveSupport::Concern
+
+      included do
+        alias_method_chain :capabilities, :bootdisk
+        alias_method_chain :parse_args, :bootdisk
+      end
+
+      def capabilities_with_bootdisk
+        capabilities_without_bootdisk + [:bootdisk]
+      end
+
+      def new_cdrom(attr = {})
+        client.cdroms.new attr
+      end
+
+      def parse_args_with_bootdisk(args = {})
+        args = parse_args_without_bootdisk args
+        if args[:provision_method] == 'bootdisk'
+          args[:cdroms] = [new_cdrom]
+          args[:boot_order] = ['cdrom', 'disk']
+        end
+        args
+      end
+
+      def bootdisk_datastore(vm_uuid)
+        find_vm_by_uuid(vm_uuid).volumes.first.datastore
+      end
+
+      def iso_upload(iso, vm_uuid)
+        options = {
+          'local_path' => iso,
+          'datacenter' => dc.name,
+          'datastore' => bootdisk_datastore(vm_uuid),
+          'upload_directory' => 'foreman_isos' # fog creates the directory if it does not exist
+        }
+        client.upload_iso options
+      end
+
+      def iso_attach(iso, vm_uuid)
+        options = {
+          'instance_uuid' => vm_uuid,
+          'iso' => "foreman_isos/#{iso}",
+          'datastore' => bootdisk_datastore(vm_uuid),
+          'start_connected' => false,
+          'connected' => true,
+          'allow_guest_control' => true
+        }
+        client.vm_reconfig_cdrom options
+      end
+    end
+  end
+end

--- a/app/models/concerns/foreman_bootdisk/host_ext.rb
+++ b/app/models/concerns/foreman_bootdisk/host_ext.rb
@@ -1,7 +1,12 @@
 require 'uri'
 
 module ForemanBootdisk::HostExt
-  extend ActiveSupport::Concerns
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method_chain :validate_media?, :bootdisk
+    alias_method_chain :can_be_built?, :bootdisk
+  end
 
   def bootdisk_template
     ProvisioningTemplate.find_by_name(Setting[:bootdisk_host_template]) || raise(::Foreman::Exception.new(N_('Unable to find template specified by %s setting'), 'bootdisk_host_template'))
@@ -18,5 +23,21 @@ module ForemanBootdisk::HostExt
 
   def bootdisk_raise(*args)
     raise ::Foreman::Exception.new(*args)
+  end
+
+  def bootdisk_build?
+    provision_method == 'bootdisk'
+  end
+
+  def bootdisk?
+    managed? && bootdisk_build? && SETTINGS[:unattended]
+  end
+
+  def validate_media_with_bootdisk?
+    validate_media_without_bootdisk? || (managed && bootdisk_build? && build?)
+  end
+
+  def can_be_built_with_bootdisk?
+    can_be_built_without_bootdisk? || (managed? and SETTINGS[:unattended] and bootdisk_build? and !build?)
   end
 end

--- a/app/models/concerns/foreman_bootdisk/orchestration/compute.rb
+++ b/app/models/concerns/foreman_bootdisk/orchestration/compute.rb
@@ -1,0 +1,86 @@
+require 'tmpdir'
+
+module ForemanBootdisk
+  module Orchestration
+    module Compute
+      extend ActiveSupport::Concern
+
+      included do
+        after_validation :queue_bootdisk_compute
+        after_build :rebuild_with_bootdisk
+      end
+
+      def bootdisk_isodir
+        @bootdisk_isodir ||= Dir.mktmpdir
+      end
+
+      def bootdisk_isofile
+        File.join(bootdisk_isodir, "#{name}.iso")
+      end
+
+      def queue_bootdisk_compute
+        return unless compute? && errors.empty? && new_record?
+        return unless provision_method == 'bootdisk'
+        queue.create(name: _('Generating ISO image for %s') % self, priority: 5,
+                     action: [self, :setGenerateIsoImage])
+        queue.create(name: _('Upload ISO image to datastore for %s') % self, priority: 6,
+                     action: [self, :setIsoImage])
+        queue.create(name: _('Attach ISO image to CDROM drive for %s') % self, priority: 1001,
+                     action: [self, :setAttachIsoImage])
+      end
+
+      def bootdisk_generate_iso_image
+        ForemanBootdisk::ISOGenerator.generate(ipxe: bootdisk_template_render, dir: Dir.tmpdir) do |image|
+          FileUtils.mv image, bootdisk_isofile
+        end
+      end
+
+      def bootdisk_upload_iso
+        compute_resource.iso_upload(bootdisk_isofile, uuid)
+      end
+
+      def bootdisk_attach_iso
+        compute_resource.iso_attach(File.basename(bootdisk_isofile), uuid)
+      end
+
+      def setGenerateIsoImage
+        logger.info 'Generating ISO image for %s' % name
+        bootdisk_generate_iso_image
+      rescue => e
+        failure _('Failed to generate ISO image for instance %{name}: %{message}') % { name: name, message: e.message }, e
+      end
+
+      def delGenerateIsoImage; end
+
+      def setIsoImage
+        logger.info "Uploading ISO image #{bootdisk_isofile} for #{name}"
+        bootdisk_upload_iso
+      rescue => e
+        failure _('Failed to upload ISO image for instance %{name}: %{message}') % { name: name, message: e.message }, e
+      end
+
+      def delIsoImage; end
+
+      def setAttachIsoImage
+        logger.info 'Attaching ISO image to CDROM drive for %s' % name
+        bootdisk_attach_iso
+      rescue => e
+        failure _('Failed to attach ISO image to CDROM drive of instance %{name}: %{message}') % { name: name, message: e.message }, e
+      end
+
+      def delAttachIsoImage; end
+
+      def rebuild_with_bootdisk
+        return true unless bootdisk?
+        begin
+          bootdisk_generate_iso_image
+          bootdisk_upload_iso
+          bootdisk_attach_iso
+        rescue => e
+          Foreman::Logging.exception "Failed to rebuild Bootdisk image for #{name}", e, :level => :error
+          return false
+        end
+      end
+    end
+  end
+end

--- a/app/views/hosts/provision_method/bootdisk/_form.html.erb
+++ b/app/views/hosts/provision_method/bootdisk/_form.html.erb
@@ -1,0 +1,4 @@
+<%= javascript 'foreman_bootdisk/host_edit' %>
+<div id='bootdisk_provisioning' <%= display? !@host.bootdisk_build? %> >
+
+</div>

--- a/test/unit/concerns/compute_resources/vmware_test.rb
+++ b/test/unit/concerns/compute_resources/vmware_test.rb
@@ -1,0 +1,76 @@
+require 'test_plugin_helper'
+
+class ForemanBootdisk::VmwareTest < ActiveSupport::TestCase
+  describe "#create_vm" do
+    setup do
+      @cr = FactoryGirl.build(:vmware_cr)
+      @cr.stubs(:test_connection)
+    end
+
+    test "does not call clone_vm when bootdisk provisioning" do
+      args = { "provision_method" => "bootdisk" }
+      mock_vm = mock('vm')
+      mock_vm.expects(:save).returns(mock_vm)
+      @cr.stubs(:parse_networks).returns(args)
+      @cr.expects(:clone_vm).times(0)
+      @cr.expects(:new_vm).returns(mock_vm)
+      @cr.create_vm(args)
+    end
+  end
+
+  describe "#new_vm" do
+    setup do
+      @cr = FactoryGirl.build(:vmware_cr)
+    end
+
+    test "calls client with cdrom drive and correct boot order when bootdisk provisioning" do
+      args = { "provision_method" => "bootdisk" }
+      mock_client = mock('client')
+      mock_servers = mock('servers')
+      mock_cdrom = mock('cdrom')
+      mock_client.expects(:servers).returns(mock_servers)
+      mock_servers.expects(:new).with() do |args|
+        assert_equal args[:boot_order], ['cdrom', 'disk']
+        assert_includes args[:cdroms], mock_cdrom
+      end
+      @cr.expects(:new_cdrom).returns(mock_cdrom)
+      @cr.expects(:new_interface)
+      @cr.expects(:new_volume)
+      @cr.expects(:datacenter)
+      @cr.expects(:client).returns(mock_client)
+      @cr.new_vm(args)
+    end
+  end
+
+  describe "#parse_args" do
+    setup do
+      @cr = FactoryGirl.build(:vmware_cr)
+    end
+
+    test "should add a cdrom drive while keeping other parameters when provision_method is bootdisk" do
+      mock_cdrom = mock('cdrom')
+      @cr.expects(:new_cdrom).returns(mock_cdrom)
+      attrs_in = HashWithIndifferentAccess.new(
+        'cpus' => '1',
+        :provision_method => 'bootdisk',
+      )
+      attrs_out = {
+        :cpus => '1',
+        :provision_method => 'bootdisk',
+        :cdroms => [mock_cdrom],
+        :boot_order => ['cdrom', 'disk'],
+      }
+      assert_equal attrs_out, @cr.parse_args(attrs_in)
+    end
+  end
+
+  describe "#capabilities" do
+    setup do
+      @cr = FactoryGirl.build(:vmware_cr)
+    end
+
+    test "should include bootdisk" do
+      assert_includes @cr.capabilities, :bootdisk
+    end
+  end
+end

--- a/test/unit/concerns/host_test.rb
+++ b/test/unit/concerns/host_test.rb
@@ -1,0 +1,43 @@
+require 'test_plugin_helper'
+
+class ForemanBootdisk::HostTest < ActiveSupport::TestCase
+  test "#bootdisk_build? must be true when provision_method is bootdisk" do
+    host = FactoryGirl.build(:host, :managed)
+    host.provision_method = 'bootdisk'
+    assert host.bootdisk_build?
+    refute host.image_build?
+    refute host.pxe_build?
+  end
+
+  test "#validate_media? must be true when provision_method is bootdisk" do
+    host = FactoryGirl.build(:host, :managed,
+                             :provision_method => "bootdisk",
+                             :build => true,
+                             )
+    assert host.validate_media?
+  end
+
+  test "#can_be_built? must be true when provision_method is bootdisk" do
+    host = FactoryGirl.build(:host, :managed,
+                             :provision_method => "bootdisk"
+                             )
+    assert host.can_be_built?
+  end
+
+
+  test "host should have bootdisk" do
+    if unattended?
+      h = FactoryGirl.build(:host, :managed,
+                            :provision_method => "bootdisk"
+                           )
+      assert h.bootdisk?
+    end
+  end
+
+  test "host should not have bootdisk" do
+    if unattended?
+      h = FactoryGirl.create(:host)
+      assert_equal false, h.bootdisk?
+    end
+  end
+end

--- a/test/unit/concerns/orchestration/compute_test.rb
+++ b/test/unit/concerns/orchestration/compute_test.rb
@@ -1,0 +1,48 @@
+require 'test_plugin_helper'
+
+class ForemanBootdisk::OrchestrationComputeTest < ActiveSupport::TestCase
+  setup do
+    disable_orchestration
+    @cr = FactoryGirl.build(:vmware_cr)
+    @host = FactoryGirl.build(:host, :managed,
+                             :compute_resource => @cr,
+                             :provision_method => "bootdisk",
+                             )
+  end
+
+  test "provisioning a host with provision method bootdisk should upload iso" do
+    @cr.expects(:iso_upload)
+    @host.send(:setIsoImage)
+  end
+
+  test "provisioning a host with provision method bootdisk should attach iso" do
+    @cr.expects(:iso_attach)
+    @host.send(:setAttachIsoImage)
+  end
+
+  test "provisioning a host with provision method bootdisk should queue bootdisk tasks" do
+    @host.stubs(:compute?).returns(true)
+    @host.send(:queue_bootdisk_compute)
+    tasks = @host.queue.all.map { |t| t.name }
+    assert_includes tasks, "Generating ISO image for #{@host.name}"
+    assert_includes tasks, "Upload ISO image to datastore for #{@host.name}"
+    assert_includes tasks, "Attach ISO image to CDROM drive for #{@host.name}"
+  end
+
+  test "should rebuild bootdisk" do
+    @host.expects(:bootdisk_generate_iso_image).returns(true)
+    @host.expects(:bootdisk_upload_iso).returns(true)
+    @host.expects(:bootdisk_attach_iso).returns(true)
+    assert @host.rebuild_with_bootdisk
+  end
+
+  test "should skip rebuild bootdisk" do
+    host = FactoryGirl.build(:host,
+                             :compute_resource => @cr
+                             )
+    host.expects(:bootdisk_generate_iso_image).never
+    host.expects(:bootdisk_upload_iso).never
+    host.expects(:bootdisk_attach_iso).never
+    assert host.rebuild_with_bootdisk
+  end
+end


### PR DESCRIPTION
This PR adds the possibility to boot off CD rather than network/image via compute resources (vmware). It's still work in progress. I would love some early feedback on this.

I also need to add tests.
Of course, this needs fog changes: https://github.com/fog/fog-vsphere/pull/13

Waiting for a new fog release.

What do you think?