### PR TITLE
Fixes #13270 - wait 5 seconds after initialization

### DIFF
--- a/app/views/foreman_bootdisk/generic_host.erb
+++ b/app/views/foreman_bootdisk/generic_host.erb
@@ -16,6 +16,7 @@
 isset ${net<%= i -%>/mac} || goto no_nic
 echo net<%= i -%> is a ${net<%= i -%>/chip} with MAC ${net<%= i -%>/mac}
 dhcp net<%= i %> || goto net<%= i+1 %>
+sleep 5
 chain <%= url %>${net<%= i -%>/mac} || goto net<%= i+1 %>
 exit 0
 <% end -%>

--- a/app/views/foreman_bootdisk/host.erb
+++ b/app/views/foreman_bootdisk/host.erb
@@ -39,6 +39,7 @@ set domain <%= interface.domain.to_s %>
 
 # Chainload from Foreman rather than embedding OS info here, so the behaviour
 # is entirely dynamic.
+sleep 5
 chain <%= bootdisk_chain_url %>
 exit 0
 


### PR DESCRIPTION
This slows down generic bootdisk process, but it can avoid problems. I was
thinking introducing a global setting, but since this is a template that can be
cloned and edited, I think this is fine.