### PR TITLE
Fixes #23713 - static credentials fail over support

### DIFF
--- a/app/views/foreman_bootdisk/generic_host.erb
+++ b/app/views/foreman_bootdisk/generic_host.erb
@@ -21,8 +21,26 @@ dhcp net<%= i %> || goto net<%= i+1 %>
 chain <%= url %>${net<%= i -%>/mac} || goto net<%= i+1 %>
 exit 0
 <% end -%>
+echo Failed to chainload from any network interface, fallback to static.
+ifstat
 
 :no_nic
-echo Failed to chainload from any network interface
-sleep 30
-exit 1
+echo -n Enter interface name to boot from (e.g. net0):  && read interface
+isset ${${interface}/mac} && goto get_static_ip
+echo Interface ${interface} is not initialized, try again
+goto no_nic
+
+:get_static_ip
+ifopen ${interface}
+echo Please enter IP details for ${interface}
+echo
+echo -n IP address      :  && read ${interface}/ip
+echo -n Subnet mask     :  && read ${interface}/netmask
+echo -n Default gateway :  && read ${interface}/gateway
+echo -n DNS server      :  && read dns
+chain <%= url %>${${interface}/mac} || goto boot_failure
+exit 0
+
+:boot_failure
+echo Cannot continue, spawning shell
+shell

--- a/app/views/foreman_bootdisk/host.erb
+++ b/app/views/foreman_bootdisk/host.erb
@@ -48,6 +48,5 @@ chain <%= bootdisk_chain_url %>
 exit 0
 
 :no_nic
-echo Cannot find interface with MAC <%= interface.mac %>
-sleep 30
-exit 1
+echo Cannot find interface with MAC <%= interface.mac %>, spawning shell
+shell


### PR DESCRIPTION
This is a patch based on an idea by Morgan Weetman and David Joo to enter
network credentials manually when DHCP is not available. I actually added this
as a fallback mechanism when DHCP attempt fails or when Foreman returns 404 on
MAC address.

In that case, a set of queries is showed and then another boot attempt is done.
If that fails, user is dropped to shell (I also changed that to be the default
behavior for both image types which seems better than useless booting loop).

I tested this in both scenarios (no DHCP response, Foreman gives 404) and it
works great. In the latter case, IP address is already pre-filled so user can
change it. We should consider adding foreman URL there as a variable so user
could verify it (and modify) too just in case.
