### PR TITLE
add host templates to iso before building

### DIFF
--- a/app/services/foreman_bootdisk/iso_generator.rb
+++ b/app/services/foreman_bootdisk/iso_generator.rb
@@ -17,6 +17,10 @@ class ForemanBootdisk::ISOGenerator
     # aim to convert filenames to something usable under ISO 9660, update the template to match
     # and then still ensure that the fetch() process stores them under the same name
     files = host.operatingsystem.pxe_files(host.medium, host.architecture, host)
+    
+    # add host templates to boot disk
+    files << {'unattended/template_'.to_sym => "http://#{host.puppetmaster}/unattended/provision?token=#{host.token}"}
+    
     files.map! do |bootfile_info|
       bootfile_info.map do |f|
         suffix = f[1].split('/').last


### PR DESCRIPTION
Hi,

pardon me for directly jumping in with a one-liner pull requests, but I didn't find issues in the theforeman/foreman_bootdisk so I'm going to file a pull request.

This pull request will cause the host templates to be included in the .iso, which is necessary at my work site to successfully build a host. I don't have any clue whether this is helpful to the general public though. Please feel free to reject my suggestion if you don't find it helpful.

Greetings
Marc
