### PR TITLE
Fixed Full Host image generation on 1.13

### DIFF
--- a/app/services/foreman_bootdisk/iso_generator.rb
+++ b/app/services/foreman_bootdisk/iso_generator.rb
@@ -10,7 +10,7 @@ class ForemanBootdisk::ISOGenerator
   def self.generate_full_host(host, opts = {}, &block)
     raise ::Foreman::Exception.new(N_('Host is not in build mode, so the template cannot be rendered')) unless host.build?
 
-    tmpl = host.send(:generate_pxe_template)
+    tmpl = host.send(:generate_pxe_template, :PXELinux)
     raise ::Foreman::Exception.new(N_('Unable to generate disk template: %s'), host.errors.full_messages.to_sentence) if tmpl == false
 
     # pxe_files and filename conversion is utterly bizarre

--- a/test/functional/foreman_bootdisk/api/v2/disks_controller_test.rb
+++ b/test/functional/foreman_bootdisk/api/v2/disks_controller_test.rb
@@ -1,6 +1,7 @@
 require 'test_plugin_helper'
 
 class ForemanBootdisk::Api::V2::DisksControllerTest < ActionController::TestCase
+  include ForemanBootdiskTestHelper
   setup :setup_bootdisk
 
   test "should generate generic image" do
@@ -12,6 +13,7 @@ class ForemanBootdisk::Api::V2::DisksControllerTest < ActionController::TestCase
   end
 
   describe "#host" do
+    setup :setup_referer
     setup :setup_host_env
 
     test "should generate host image" do

--- a/test/functional/foreman_bootdisk/api/v2/subnet_disks_controller_test.rb
+++ b/test/functional/foreman_bootdisk/api/v2/subnet_disks_controller_test.rb
@@ -1,9 +1,11 @@
 require 'test_plugin_helper'
 
 class ForemanBootdisk::Api::V2::SubnetDisksControllerTest < ActionController::TestCase
+  include ForemanBootdiskTestHelper
   setup :setup_bootdisk
 
   describe "#subnet_host" do
+    setup :setup_referer
     setup :setup_org_loc
     setup :setup_subnet
     setup :setup_host

--- a/test/functional/foreman_bootdisk/disks_controller_test.rb
+++ b/test/functional/foreman_bootdisk/disks_controller_test.rb
@@ -1,6 +1,7 @@
 require 'test_plugin_helper'
 
 class ForemanBootdisk::DisksControllerTest < ActionController::TestCase
+  include ForemanBootdiskTestHelper
   setup :setup_bootdisk
 
   test "should generate generic image" do
@@ -12,6 +13,7 @@ class ForemanBootdisk::DisksControllerTest < ActionController::TestCase
   end
 
   describe "#host" do
+    setup :setup_referer
     setup :setup_org_loc
     setup :setup_subnet
     setup :setup_host
@@ -44,6 +46,7 @@ class ForemanBootdisk::DisksControllerTest < ActionController::TestCase
   end
 
   describe "#host without tftp" do
+    setup :setup_referer
     setup :setup_org_loc
     setup :setup_subnet_no_tftp
     setup :setup_host

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ActionController::TestCase
+module ForemanBootdiskTestHelper
   def setup_bootdisk
     setup_routes
     setup_settings
@@ -25,9 +25,12 @@ class ActionController::TestCase
     load File.join(File.dirname(__FILE__), '..', 'db', 'seeds.d', '50-bootdisk_templates.rb')
   end
 
+  def setup_referer
+    request.env["HTTP_REFERER"] = "/history"
+  end
+
   def setup_org_loc
     disable_orchestration
-    request.env["HTTP_REFERER"] = "/history"
     @org, @loc = FactoryGirl.create(:organization), FactoryGirl.create(:location)
   end
 

--- a/test/unit/iso_generator_test.rb
+++ b/test/unit/iso_generator_test.rb
@@ -1,0 +1,21 @@
+require 'test_plugin_helper'
+
+class ForemanBootdisk::IsoGeneratorTest < ActiveSupport::TestCase
+  include ForemanBootdiskTestHelper
+  setup :setup_bootdisk
+  setup :setup_org_loc
+  setup :setup_subnet
+  setup :setup_host
+
+  setup do
+    @host.build = true
+  end
+
+  test "full host image generation generates via PXELinux type" do
+    @host.operatingsystem.expects(:pxe_files).returns([])
+    @host.operatingsystem.expects(:kernel).returns("kernel")
+    @host.operatingsystem.expects(:initrd).returns("initrd")
+    ForemanBootdisk::ISOGenerator.expects(:generate).with({:isolinux => nil, :files => []}, anything)
+    ForemanBootdisk::ISOGenerator.generate_full_host(@host)
+  end
+end


### PR DESCRIPTION
PXELoader flag in 1.13 broke Full Host generation as the parameter is not
passed. We can fix this here, or I can provide default parameter in core to
remain compatibility (but it can bite). I prefer being explicit.

Anyway, this is bad regression, any chance to squeeze this into 1.13 plugin? Do
you want me to do a ticket?