### PR TITLE
Fixes #17552 - set default api version to v2

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ ForemanBootdisk::Engine.routes.draw do
   end
 
   namespace :api, :defaults => {:format => 'json'} do
-    scope "(:apiv)", :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2) do
+    scope "(:apiv)", :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do
       get 'generic', :to => 'disks#generic'
       constraints(:id => /[^\/]+/) do
         get 'hosts/:id', :to => 'disks#host'

--- a/test/functional/foreman_bootdisk/api/v2/disks_controller_test.rb
+++ b/test/functional/foreman_bootdisk/api/v2/disks_controller_test.rb
@@ -12,9 +12,7 @@ class ForemanBootdisk::Api::V2::DisksControllerTest < ActionController::TestCase
   end
 
   describe "#host" do
-    setup :setup_org_loc
-    setup :setup_subnet
-    setup :setup_host
+    setup :setup_host_env
 
     test "should generate host image" do
       ForemanBootdisk::ISOGenerator.expects(:generate).with(has_entry(:ipxe => regexp_matches(/disk host template/))).yields("temp ISO")
@@ -30,6 +28,27 @@ class ForemanBootdisk::Api::V2::DisksControllerTest < ActionController::TestCase
       get :host, {:id => @host.name, :full => true}
       assert_response :success
       assert_equal "ISO image", @response.body
+    end
+  end
+
+  describe "default API version 2" do
+    setup :setup_host_env
+
+    test "path - /api/hosts/:host_id routes to #host" do
+      assert_routing "/api/hosts/#{@host.id}",
+                     :format     => "json",
+                     :apiv       => "v2",
+                     :controller => "foreman_bootdisk/api/v2/disks",
+                     :action     => "host",
+                     :id         => @host.id.to_s
+    end
+
+    test "path - /api/generic routes to #generic" do
+      assert_routing "/api/generic",
+                     :format     => "json",
+                     :apiv       => "v2",
+                     :controller => "foreman_bootdisk/api/v2/disks",
+                     :action     => "generic"
     end
   end
 end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -7,6 +7,12 @@ class ActionController::TestCase
     setup_templates
   end
 
+  def setup_host_env
+    setup_org_loc
+    setup_subnet
+    setup_host
+  end
+
   def setup_routes
     @routes = ForemanBootdisk::Engine.routes
   end


### PR DESCRIPTION
Apipie doc falsely states url(s) for bootdisk API calls.
Example: `/api/generic` should have been `/bootdisk/api/v2/generic`.
I wasn't sure how to test it. Should the API url be tested from foreman?