### PR TITLE
Full Host disk DHCP reservation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ TFTP settings are needed.
   <tr>
     <td>Full host image</td>
     <td>No</td>
-    <td>Yes</td>
+    <td>No (*)</td>
     <td>No</td>
     <td>Yes</td>
     <td>Yes</td>
@@ -143,6 +143,8 @@ TFTP settings are needed.
     <td>No</td>
   </tr>
 </table>
+
+(*) - Foreman 1.14 or older do require DHCP
 
 ### Per-host images
 


### PR DESCRIPTION
This is no longer the case with 1.15 templates:

https://github.com/theforeman/community-templates/pull/326/files