### PR TITLE
refs #19733 - remove duplicate templates

### DIFF
--- a/db/migrate/20171009225200_remove_duplicate_bootdisk_templates.rb
+++ b/db/migrate/20171009225200_remove_duplicate_bootdisk_templates.rb
@@ -1,0 +1,9 @@
+class RemoveDuplicateBootdiskTemplates < ActiveRecord::Migration
+  def up
+    template_names = ['Boot disk iPXE - host', 'Boot disk iPXE - generic host']
+    template_names.each do |template_name|
+      duplicate_template_ids = ProvisioningTemplate.unscoped.where(:name => template_name, :locked => true).order(:created_at => :asc).pluck(:id).drop(1)
+      ProvisioningTemplate.unscoped.where(:id => duplicate_template_ids).destroy_all if duplicate_template_ids.any?
+    end
+  end
+end


### PR DESCRIPTION
This is an addition to https://github.com/theforeman/foreman_bootdisk/pull/42. It adds a migration to automatically remove extra seeded Provisioning Templates.