### PR TITLE
Fixes #21877 - fixed rake tasks with taxonomy

### DIFF
--- a/app/models/concerns/foreman_bootdisk/host_ext.rb
+++ b/app/models/concerns/foreman_bootdisk/host_ext.rb
@@ -2,7 +2,7 @@ require 'uri'
 
 module ForemanBootdisk::HostExt
   def bootdisk_template
-    ProvisioningTemplate.find_by_name(Setting[:bootdisk_host_template]) || raise(::Foreman::Exception.new(N_('Unable to find template specified by %s setting'), 'bootdisk_host_template'))
+    ProvisioningTemplate.unscoped.find_by_name(Setting[:bootdisk_host_template]) || raise(::Foreman::Exception.new(N_('Unable to find template specified by %s setting'), 'bootdisk_host_template'))
   end
 
   def bootdisk_template_render

--- a/app/services/foreman_bootdisk/renderer.rb
+++ b/app/services/foreman_bootdisk/renderer.rb
@@ -8,7 +8,7 @@ module ForemanBootdisk
     include RendererMethods
 
     def generic_template_render(subnet = nil)
-      tmpl = ProvisioningTemplate.find_by_name(Setting[:bootdisk_generic_host_template]) || raise(::Foreman::Exception.new(N_('Unable to find template specified by %s setting'), 'bootdisk_generic_host_template'))
+      tmpl = ProvisioningTemplate.unscoped.find_by_name(Setting[:bootdisk_generic_host_template]) || raise(::Foreman::Exception.new(N_('Unable to find template specified by %s setting'), 'bootdisk_generic_host_template'))
 
       if subnet.present?
         # rendering a subnet-level bootdisk requires tricking the renderer into thinking it has a


### PR DESCRIPTION
Taxonomy is now enforced which returns nil for the templates. Both templates are global, thus taxonomy is not relevant. For rake tasks, this is also irrelevant. So added `unscoped` everywhere.