### PR TITLE
fixes #22428 - subnet img should use provision_interface

### DIFF
--- a/app/services/foreman_bootdisk/renderer.rb
+++ b/app/services/foreman_bootdisk/renderer.rb
@@ -13,9 +13,9 @@ module ForemanBootdisk
       if subnet.present?
         # rendering a subnet-level bootdisk requires tricking the renderer into thinking it has a
         # valid host, with a token, and with a tftp proxy
-        @host = Struct.new(:token, :subnet).new(
+        @host = Struct.new(:token, :provision_interface).new(
           Struct.new(:value).new('faketoken'),
-          subnet
+          Struct.new(:subnet).new(subnet)
         )
       else
         @host = Struct.new(:token, :subnet).new(nil,nil)


### PR DESCRIPTION
In order to generate a subnet image correctly, we have to create a mock
host that uses that subnet.  It currently uses the old Foreman methods
where a host subnet was directly attached to the host, instead of
an interface.

This updates the fake host to use provison_interface instead.  This
correctly generates an image that references proxy URL when template
proxy is enabled.