### PR TITLE
Fixes #22858 - Move MAC based identification to Foreman core

### DIFF
--- a/app/controllers/concerns/foreman_bootdisk/unattended_controller_ext.rb
+++ b/app/controllers/concerns/foreman_bootdisk/unattended_controller_ext.rb
@@ -1,6 +1,0 @@
-module ForemanBootdisk::UnattendedControllerExt
-  def find_host_by_ip_or_mac
-    request.env['HTTP_X_RHN_PROVISIONING_MAC_0'] = "unknown #{params['mac']}" unless request.env.has_key?('HTTP_X_RHN_PROVISIONING_MAC_0') || params['mac'].nil?
-    super
-  end
-end

--- a/lib/foreman_bootdisk/engine.rb
+++ b/lib/foreman_bootdisk/engine.rb
@@ -48,7 +48,7 @@ module ForemanBootdisk
 
     initializer 'foreman_bootdisk.register_plugin', :before => :finisher_hook do |app|
       Foreman::Plugin.register :foreman_bootdisk do
-        requires_foreman '>= 1.17'
+        requires_foreman '>= 1.18'
 
         security_block :bootdisk do |map|
           permission :download_bootdisk, {:'foreman_bootdisk/disks' => [:generic, :host, :full_host, :subnet, :help],
@@ -79,7 +79,6 @@ module ForemanBootdisk
         Host::Managed.send(:prepend, ForemanBootdisk::HostExt)
         Host::Managed.send(:include, ForemanBootdisk::Orchestration::Compute) if SETTINGS[:unattended]
         HostsHelper.send(:prepend, ForemanBootdisk::HostsHelperExt)
-        UnattendedController.send(:prepend, ForemanBootdisk::UnattendedControllerExt)
         Foreman::Model::Vmware.send(:prepend, ForemanBootdisk::ComputeResources::Vmware) if Foreman::Model::Vmware.available?
       rescue => e
         puts "#{ForemanBootdisk::ENGINE_NAME}: skipping engine hook (#{e.to_s})"


### PR DESCRIPTION
This removes the `unattended_controller` extension as the MAC based identification has been merged into the core.

See also: https://github.com/theforeman/foreman/pull/5290

Please let me know if I missed any reference.