### PR TITLE
Fixes #4413 - Full-host bootdisk image UEFI compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ locale/*/*.pox
 tags
 TAGS
 .foreman_app
-bootloaders
+/bootloaders
+/foreman_bootdisk*gem

--- a/app/models/setting/bootdisk.rb
+++ b/app/models/setting/bootdisk.rb
@@ -1,4 +1,6 @@
 class Setting::Bootdisk< ::Setting
+  BLANK_ATTRS << "bootdisk_efiboot_dir"
+
   def self.load_defaults
     return unless ApplicationRecord.connection.table_exists?('settings')
     return unless super
@@ -13,6 +15,7 @@ class Setting::Bootdisk< ::Setting
         self.set('bootdisk_ipxe_dir', N_('Path to directory containing iPXE images'), ipxe, N_('iPXE directory')),
         self.set('bootdisk_isolinux_dir', N_('Path to directory containing isolinux images'), isolinux, N_('ISOLINUX directory')),
         self.set('bootdisk_syslinux_dir', N_('Path to directory containing syslinux images'), syslinux, N_('SYSLINUX directory')),
+        self.set('bootdisk_efiboot_dir', N_('Path to directory containing efiboot.img (leave empty for BIOS only)'), '', N_('EFI image directory')),
         self.set('bootdisk_host_template', N_('iPXE template to use for host-specific boot disks'), 'Boot disk iPXE - host', N_('Host image template'), nil, :collection => templates),
         self.set('bootdisk_generic_host_template', N_('iPXE template to use for generic host boot disks'), 'Boot disk iPXE - generic host', N_('Generic image template'), nil, :collection => templates),
         self.set('bootdisk_mkiso_command', N_('Command to generate ISO image, use genisoimage or mkisofs'), 'genisoimage', N_('ISO generation command')),

--- a/app/services/foreman_bootdisk/iso_generator.rb
+++ b/app/services/foreman_bootdisk/iso_generator.rb
@@ -10,10 +10,11 @@ class ForemanBootdisk::ISOGenerator
   def self.generate_full_host(host, opts = {}, &block)
     raise ::Foreman::Exception.new(N_('Host is not in build mode, so the template cannot be rendered')) unless host.build?
 
-    tmpl = host.send(:generate_pxe_template, :PXELinux)
-    unless tmpl
+    pxelinux_template = host.send(:generate_pxe_template, :PXELinux)
+    pxegrub2_template = host.send(:generate_pxe_template, :PXEGrub2) if Setting[:bootdisk_efiboot_dir].present?
+    unless (pxelinux_template && pxegrub2_template)
       err = host.errors.full_messages.to_sentence
-      raise ::Foreman::Exception.new(N_('Unable to generate disk template, PXELinux template not found or: %s'), err)
+      raise ::Foreman::Exception.new(N_('Unable to generate disk template, PXELinux/Grub2 template not found or: %s'), err)
     end
 
     # pxe_files and filename conversion is utterly bizarre
@@ -24,13 +25,14 @@ class ForemanBootdisk::ISOGenerator
       bootfile_info.map do |f|
         suffix = f[1].split('/').last
         iso_f0 = iso9660_filename(f[0].to_s + '_' + suffix)
-        tmpl.gsub!(f[0].to_s + '-' + suffix, iso_f0)
+        pxelinux_template.gsub!(f[0].to_s + '-' + suffix, iso_f0)
+        pxegrub2_template.gsub!(f[0].to_s + '-' + suffix, '/' + iso_f0) if pxegrub2_template
         ForemanBootdisk.logger.debug("Boot file #{iso_f0}, source #{f[1]}")
         [iso_f0, f[1]]
       end
     end
 
-    generate(opts.merge(:isolinux => tmpl, :files => files), &block)
+    generate(opts.merge(:isolinux => pxelinux_template, :grub => pxegrub2_template, :files => files), &block)
   end
 
   def self.generate(opts = {}, &block)
@@ -39,6 +41,16 @@ class ForemanBootdisk::ISOGenerator
       label ipxe
       kernel /ipxe
       initrd /script
+    EOS
+
+    opts[:grub] = <<-EOS if opts[:grub].nil? && opts[:ipxe]
+set default=0
+set timeout=5
+menuentry "Chainload iPXE chain" {
+  search --no-floppy --set=root -f /ipxe.efi
+  chainloader ($root)/ipxe.efi
+  boot echo HELLO
+}
     EOS
 
     Dir.mktmpdir('bootdisk') do |wd|
@@ -62,6 +74,13 @@ class ForemanBootdisk::ISOGenerator
           raise ::Foreman::Exception.new(N_("Please ensure the ipxe-bootimgs package is installed."))
         end
         FileUtils.cp(File.join(Setting[:bootdisk_ipxe_dir], 'ipxe.lkrn'), File.join(wd, 'build', 'ipxe'))
+        if File.exists?(File.join(Setting[:bootdisk_ipxe_dir], 'ipxe.efi'))
+          FileUtils.cp(File.join(Setting[:bootdisk_ipxe_dir], 'ipxe.efi'), File.join(wd, 'build', 'ipxe.efi'))
+        elsif File.exists?(File.join(Setting[:bootdisk_ipxe_dir], 'ipxe-x86_64.efi'))
+          FileUtils.cp(File.join(Setting[:bootdisk_ipxe_dir], 'ipxe-x86_64.efi'), File.join(wd, 'build', 'ipxe.efi'))
+        else
+          raise ::Foreman::Exception.new(N_("Please ensure the iPXE directory contains ipxe.efi."))
+        end
         File.open(File.join(wd, 'build', 'script'), 'w') { |file| file.write(opts[:ipxe]) }
       end
 
@@ -78,13 +97,30 @@ class ForemanBootdisk::ISOGenerator
             else
               File.join(wd, 'output.iso')
             end
-      unless system("#{Setting[:bootdisk_mkiso_command]} -o #{iso} -iso-level 2 -b isolinux.bin -c boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table #{File.join(wd, 'build')}")
-        raise ::Foreman::Exception.new(N_("ISO build failed"))
+
+      if Setting[:bootdisk_efiboot_dir].present?
+        FileUtils.mkdir_p(File.join(wd, 'build', 'EFI', 'BOOT'))
+        FileUtils.cp(File.join(Setting[:bootdisk_efiboot_dir], 'efiboot.img'), File.join(wd, 'build', 'EFI', 'BOOT', 'efiboot.img'))
+        File.open(File.join(wd, 'build', 'EFI', 'BOOT', 'grub.cfg'), 'w') do |file|
+          file.write(opts[:grub])
+        end
+        efiopts = "-eltorito-alt-boot -e EFI/BOOT/efiboot.img -no-emul-boot"
+        isohybrid_command = "isohybrid --uefi #{iso}"
+      else
+        efiopts = ''
+        isohybrid_command = "isohybrid #{iso}"
+      end
+
+      mkiso_command = "#{Setting[:bootdisk_mkiso_command]} -o #{iso} -iso-level 2 -b isolinux.bin -c boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table #{efiopts} #{File.join(wd, 'build')}"
+      ForemanBootdisk.logger.info("Executing: #{mkiso_command}")
+      unless system(mkiso_command)
+        raise ::Foreman::Exception.new(N_("ISO build failed") + ': ' + mkiso_command)
       end
 
       # Make the ISO bootable as a HDD/USB disk too
-      unless system("isohybrid", iso)
-        raise ::Foreman::Exception.new(N_("ISO hybrid conversion failed"))
+      ForemanBootdisk.logger.info("Executing: #{isohybrid_command}")
+      unless system(isohybrid_command)
+        raise ::Foreman::Exception.new(N_("ISO hybrid conversion failed") + ': ' + isohybrid_command)
       end
 
       yield iso


### PR DESCRIPTION
I want to start over, rebased. This is WIP.

By default this patch should not change anything, but if user copies
efiboot.img and grubx64.efi into a directory and sets this in the settings,
Full Host image will be created with EFI in mind (as hybrid ISO as well). So
the ISO will work both on BIOS and EFI systems.

For RHEL systems, the file can be only find in the kickstart tree:

http://ftp.fi.muni.cz/pub/linux/centos/7/os/x86_64/images/

Grub2 file can be found in grub2-efi package.