### PR TITLE
Fixes #23738 - added generic static host template

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+require:
+  - rubocop-performance
+  - rubocop-rails
+
 AllCops:
   TargetRubyVersion: 2.3
   TargetRailsVersion: 5.2
@@ -8,13 +12,7 @@ AllCops:
 Rails:
   Enabled: true
 
-Style/Documentation:
-  Enabled: false
-
-Style/FormatStringToken:
-  Enabled: false
-
-Style/DoubleNegation:
+Style:
   Enabled: false
 
 Metrics:
@@ -32,19 +30,6 @@ Rails/Date:
   Exclude:
     - 'lib/tasks/**/*'
 
-Style/ClassAndModuleChildren:
-  Exclude:
-    - 'test/functional/**/*'
-
 Naming/FileName:
   Exclude:
     - 'db/seeds.d/**/*'
-
-# Support both ruby19 and hash_rockets
-Style/HashSyntax:
-  EnforcedStyle: no_mixed_keys
-  Enabled: true
-
-# Both double and single quotes are OK
-Style/StringLiterals:
-  Enabled: false

--- a/README.md
+++ b/README.md
@@ -236,6 +236,22 @@ To generate from the command line on the Foreman server:
 Set `OUTPUT=/path` to change the output destination path (directory or file).
 It must be writable by the 'foreman' user.
 
+### Generic static image
+
+This is generic image type which asks for network credentials instead of doing
+DHCP request. Tokens must be turned off in order to find the host by MAC
+address. To do that, set Token duration to 0 in Administer - Settings.
+
+- Network interface name
+- IP Address
+- Netmask
+- Gateway
+- DNS
+
+To use generic static host image, set "Generic image template" to "Bootdisk
+iPXE - host template" in Administer - Settings - Boot disk. Only one template
+can be used at one time across all hosts.
+
 ### Subnet images
 
 Subnet images are similar to generic images, but chain-loading is done via the

--- a/app/helpers/concerns/foreman_bootdisk/hosts_helper_ext.rb
+++ b/app/helpers/concerns/foreman_bootdisk/hosts_helper_ext.rb
@@ -2,27 +2,27 @@
 
 module ForemanBootdisk
   module HostsHelperExt
-    def host_title_actions(*args)
-      if @host.bootdisk_downloadable?
+    def host_title_actions(host)
+      if host.bootdisk_downloadable?
         title_actions(
           button_group(
             select_action_button(
               _('Boot disk'), { class: 'btn btn-group' },
               display_bootdisk_link_if_authorized(
-                _("Host '%s' image") % @host.name.split('.')[0],
+                _("Host '%s' image") % host.name.split('.')[0],
                 {
                   controller: 'foreman_bootdisk/disks',
                   action: 'host',
-                  id: @host
+                  id: host
                 },
                 class: 'la'
               ),
               display_bootdisk_link_if_authorized(
-                _("Full host '%s' image") % @host.name.split('.')[0],
+                _("Full host '%s' image") % host.name.split('.')[0],
                 {
                   controller: 'foreman_bootdisk/disks',
                   action: 'full_host',
-                  id: @host
+                  id: host
                 },
                 class: 'la'
               ),
@@ -35,7 +35,7 @@ module ForemanBootdisk
                 },
                 class: 'la'
               ),
-              display_bootdisk_for_subnet,
+              display_bootdisk_for_subnet(host),
               content_tag(:li, '', class: 'divider'),
               display_bootdisk_link_if_authorized(
                 _('Help'), {
@@ -48,29 +48,29 @@ module ForemanBootdisk
           )
         )
       else
-        bootdisk_button_disabled
+        bootdisk_button_disabled(host)
       end
 
       super
     end
 
-    def bootdisk_button_disabled
+    def bootdisk_button_disabled(host)
       title_actions(
         button_group(
           link_to(_('Boot disk'), '#', disabled: true, class: 'btn btn-default',
-                                       title: _('Boot disk download not available for %s architecture') % @host.architecture.name)
+                                       title: _('Boot disk download not available for %s architecture') % host.architecture.name)
         )
       )
     end
 
     # need to wrap this one in a test for template proxy presence
-    def display_bootdisk_for_subnet
-      if (proxy = @host.try(:subnet).try(:tftp)) && proxy.has_feature?('Templates')
+    def display_bootdisk_for_subnet(host)
+      if (proxy = host.try(:subnet).try(:tftp)) && proxy.has_feature?('Templates')
         display_bootdisk_link_if_authorized(
-          _("Subnet '%s' generic image") % @host.subnet.name, {
+          _("Subnet '%s' generic image") % host.subnet.name, {
             controller: 'foreman_bootdisk/disks',
             action: 'subnet',
-            id: @host
+            id: host
           },
           class: 'la'
         )

--- a/app/services/foreman_bootdisk/iso_generator.rb
+++ b/app/services/foreman_bootdisk/iso_generator.rb
@@ -11,7 +11,7 @@ require 'uri'
 module ForemanBootdisk
   class ISOGenerator
     def self.generate_full_host(host, opts = {}, &block)
-      raise Foreman::Exception, N_('Host is not in build mode, so the template cannot be rendered') unless host.build?
+      raise(Foreman::Exception, N_('Host is not in build mode, so the template cannot be rendered')) unless host.build?
 
       tmpl = render_pxelinux_template(host)
 
@@ -30,7 +30,7 @@ module ForemanBootdisk
     def self.render_pxelinux_template(host)
       pxelinux_template = host.provisioning_template(kind: :PXELinux)
 
-      raise Foreman::Exception, N_('Unable to generate disk template, PXELinux template not found.') unless pxelinux_template
+      raise(Foreman::Exception, N_('Unable to generate disk template, PXELinux template not found.')) unless pxelinux_template
 
       template = ForemanBootdisk::Renderer.new.render_template(
         template: pxelinux_template,
@@ -40,7 +40,7 @@ module ForemanBootdisk
 
       unless template
         err = host.errors.full_messages.to_sentence
-        raise ::Foreman::Exception.new(N_('Unable to generate disk PXELinux template: %s'), err)
+        raise(::Foreman::Exception.new(N_('Unable to generate disk PXELinux template: %s'), err))
       end
 
       template
@@ -59,7 +59,7 @@ module ForemanBootdisk
 
         if opts[:isolinux]
           isolinux_source_file = File.join(Setting[:bootdisk_isolinux_dir], 'isolinux.bin')
-          raise Foreman::Exception, N_('Please ensure the isolinux/syslinux package(s) are installed.') unless File.exist?(isolinux_source_file)
+          raise(Foreman::Exception, N_('Please ensure the isolinux/syslinux package(s) are installed.')) unless File.exist?(isolinux_source_file)
 
           FileUtils.cp(isolinux_source_file, File.join(wd, 'build', 'isolinux.bin'))
 
@@ -76,7 +76,7 @@ module ForemanBootdisk
 
         if opts[:ipxe]
           ipxe_source_file = File.join(Setting[:bootdisk_ipxe_dir], 'ipxe.lkrn')
-          raise Foreman::Exception, N_('Please ensure the ipxe-bootimgs package is installed.') unless File.exist?(ipxe_source_file)
+          raise(Foreman::Exception, N_('Please ensure the ipxe-bootimgs package is installed.')) unless File.exist?(ipxe_source_file)
 
           FileUtils.cp(ipxe_source_file, File.join(wd, 'build', 'ipxe'))
           File.open(File.join(wd, 'build', 'script'), 'w') { |file| file.write(opts[:ipxe]) }
@@ -95,10 +95,10 @@ module ForemanBootdisk
               else
                 File.join(wd, 'output.iso')
               end
-        raise Foreman::Exception, N_('ISO build failed') unless system(build_mkiso_command(output_file: iso, source_directory: File.join(wd, 'build')))
+        raise(Foreman::Exception, N_('ISO build failed')) unless system(build_mkiso_command(output_file: iso, source_directory: File.join(wd, 'build')))
 
         # Make the ISO bootable as a HDD/USB disk too
-        raise Foreman::Exception, N_('ISO hybrid conversion failed') unless system('isohybrid', iso)
+        raise(Foreman::Exception, N_('ISO hybrid conversion failed')) unless system('isohybrid', iso)
 
         yield iso
       end

--- a/app/views/foreman_bootdisk/generic_static_host.erb
+++ b/app/views/foreman_bootdisk/generic_static_host.erb
@@ -1,0 +1,34 @@
+#!ipxe
+#
+# Generic host template with interactive static IP configuration. Tokens
+# must be disabled in order to access templates via MAC addresses.
+#
+
+<% (0..32).each do |i| -%>
+:net<%= i %>
+isset ${net<%= i -%>/mac} || goto configure
+echo Found ${net<%= i -%>/mac} as net<%= i -%> on a ${net<%= i -%>/chip}
+goto net<%= i+1 %>
+<% end -%>
+
+:configure
+echo -n Interface (e.g. net0): && read interface
+iseq ${interface} n && goto reboot ||
+iseq ${interface} N && goto reboot ||
+
+ifopen ${interface}
+echo Please enter IPv4 details for ${interface}
+echo
+
+echo -n IP address:  && read ${interface}/ip
+echo -n Subnet mask:  && read ${interface}/netmask
+echo -n Default gateway:  && read ${interface}/gateway
+echo -n DNS server:  && read dns
+
+chain <%= bootdisk_chain_url %>${${interface}/mac} || goto reboot
+exit 0
+
+:reboot
+echo Unable to continue, rebooting...
+sleep 30
+exit 1

--- a/db/seeds.d/50-bootdisk_templates.rb
+++ b/db/seeds.d/50-bootdisk_templates.rb
@@ -1,48 +1,31 @@
 # frozen_string_literal: true
 
-kind = TemplateKind.unscoped.where(name: 'Bootdisk').first_or_create
+def read_bootdisk_template(filename)
+  File.read(File.join(ForemanBootdisk::Engine.root, 'app', 'views', 'foreman_bootdisk', filename))
+end
 
-organizations = Organization.all
-locations = Location.all
-created = []
+def ensure_bootdisk_template(name, content)
+  kind = TemplateKind.unscoped.where(name: 'Bootdisk').first_or_create
+  tmpl = ProvisioningTemplate.unscoped.where(name: name).first_or_create do |template|
+    template.attributes = {
+      template_kind_id: kind.id,
+      snippet: false,
+      template: content
+    }
+  end
+  tmpl.attributes = {
+    template: content,
+    default: true,
+    vendor: "Foreman boot disk"
+  }
+  tmpl.locked = true
+  tmpl.organizations = Organization.unscoped.all if SETTINGS[:organizations_enabled]
+  tmpl.locations = Location.unscoped.all if SETTINGS[:locations_enabled]
+  tmpl.save!(validate: false) if tmpl.changes.present?
+end
 
 ProvisioningTemplate.without_auditing do
-  content = File.read(File.join(ForemanBootdisk::Engine.root, 'app', 'views', 'foreman_bootdisk', 'host.erb'))
-  created << 'Boot disk iPXE - host' unless ProvisioningTemplate.find_by(name: 'Boot disk iPXE - host')
-  tmpl = ProvisioningTemplate.unscoped.where(name: 'Boot disk iPXE - host').first_or_create do |template|
-    template.attributes = {
-      template_kind_id: kind.id,
-      snippet: false,
-      template: content
-    }
-  end
-  tmpl.attributes = {
-    template: content,
-    default: true,
-    vendor: 'Foreman boot disk'
-  }
-  tmpl.locked = true
-  tmpl.save!(validate: false) if tmpl.changes.present?
-
-  content = File.read(File.join(ForemanBootdisk::Engine.root, 'app', 'views', 'foreman_bootdisk', 'generic_host.erb'))
-  created << 'Boot disk iPXE - generic host' unless ProvisioningTemplate.find_by(name: 'Boot disk iPXE - generic host')
-  tmpl = ProvisioningTemplate.unscoped.where(name: 'Boot disk iPXE - generic host').first_or_create do |template|
-    template.attributes = {
-      template_kind_id: kind.id,
-      snippet: false,
-      template: content
-    }
-  end
-  tmpl.attributes = {
-    template: content,
-    default: true,
-    vendor: 'Foreman boot disk'
-  }
-  tmpl.locked = true
-  tmpl.save!(validate: false) if tmpl.changes.present?
-
-  ProvisioningTemplate.unscoped.where(name: created, default: true).each do |template|
-    template.organizations = organizations if SETTINGS[:organizations_enabled]
-    template.locations = locations if SETTINGS[:locations_enabled]
-  end
+  ensure_bootdisk_template("Boot disk iPXE - host", read_bootdisk_template("host.erb"))
+  ensure_bootdisk_template("Boot disk iPXE - generic host", read_bootdisk_template("generic_host.erb"))
+  ensure_bootdisk_template("Boot disk iPXE - generic static host", read_bootdisk_template("generic_static_host.erb"))
 end

--- a/foreman_bootdisk.gemspec
+++ b/foreman_bootdisk.gemspec
@@ -25,5 +25,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n") - Dir['.*', 'Gem*', '*.gemspec']
 
   s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop-performance'
+  s.add_development_dependency 'rubocop-rails'
   s.add_development_dependency 'webmock'
 end

--- a/release-gem
+++ b/release-gem
@@ -1,4 +1,6 @@
 #!/bin/env ruby
+# frozen_string_literal: true
+# rubocop:disable all
 
 $plugin_name = "foreman_bootdisk"
 RUBY_VERSION_FILE = "lib/#{$plugin_name}/version.rb"


### PR DESCRIPTION
New template which can be used in Administer - Settings - Boot disk for Generic
host image generation.

Replaces:

* https://github.com/theforeman/foreman_bootdisk/pull/15
* https://github.com/theforeman/foreman_bootdisk/pull/61

/CC @glimpsovstar