### PR TITLE
Refs #21833 - fixed initialization order for bootsnap

### DIFF
--- a/lib/foreman_bootdisk/engine.rb
+++ b/lib/foreman_bootdisk/engine.rb
@@ -10,7 +10,7 @@ module ForemanBootdisk
     config.autoload_paths += Dir["#{config.root}/app/helpers/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/models/concerns"]
 
-    initializer 'foreman_bootdisk.mount_engine', :after=> :build_middleware_stack do |app|
+    initializer 'foreman_bootdisk.mount_engine' do |app|
       app.routes_reloader.paths << "#{ForemanBootdisk::Engine.root}/config/routes/mount_engine.rb"
     end
 


### PR DESCRIPTION
I was made aware by @carbonin that this prevents Bootsnap from correctly starting tests when Rails Engine is enabled. I was trying to figure this out for months! https://github.com/Shopify/bootsnap/issues/106

I have no idea why we have this in our codebase, but the endpoint just works after this change. If tests pass let's give it a go!