### PR TITLE
Fixes #25986 - generic disk generates with katello

### DIFF
--- a/app/services/foreman_bootdisk/renderer.rb
+++ b/app/services/foreman_bootdisk/renderer.rb
@@ -13,7 +13,7 @@ module ForemanBootdisk
                  Struct.new(:subnet).new(subnet)
                )
              else
-               Struct.new(:token, :subnet).new(nil, nil)
+               Struct.new(:token, :subnet, :content_source).new(nil, nil, nil)
              end
 
       render_template(template: generic_host_template, host: host)


### PR DESCRIPTION
New media provider broke behavior of the hack in bootdisk.