### PR TITLE
Fixes #26512 - stub content_source for generic disk

### DIFF
--- a/app/services/foreman_bootdisk/renderer.rb
+++ b/app/services/foreman_bootdisk/renderer.rb
@@ -8,9 +8,10 @@ module ForemanBootdisk
       host = if subnet.present?
                # rendering a subnet-level bootdisk requires tricking the renderer into thinking it has a
                # valid host, without a token, but with a tftp proxy
-               Struct.new(:token, :provision_interface).new(
+               Struct.new(:token, :provision_interface, :content_source).new(
                  nil,
-                 Struct.new(:subnet).new(subnet)
+                 Struct.new(:subnet).new(subnet),
+                 nil
                )
              else
                Struct.new(:token, :subnet, :content_source).new(nil, nil, nil)


### PR DESCRIPTION
When generic bootdisk is used with Katello, it fails due to missing method which is needed. Although providing a stub in bootdisk for Katello might sound weird and I would be totally against tight coupling of plugins, the whole way of generating generic bootdisk images is a hack and should be rewritten from the ground up.

FYI this is continuation of https://github.com/theforeman/foreman_bootdisk/pull/74 where I forgot to update the other part of the if statement.