### PR TITLE
#27651 Provision using vlan tagging boot iso

### DIFF
--- a/app/views/foreman_bootdisk/host.erb
+++ b/app/views/foreman_bootdisk/host.erb
@@ -40,6 +40,19 @@ goto loop_success
 
 :loop_success
 echo Configuring net${idx} for static IP address <%= ip %>
+<% if interface.tag.present? && interface.attached_to.present? %>
+vcreate --tag <%= interface.tag %> net${idx}
+ifopen net${idx}-<%= interface.tag %>
+# netX = last opened NIC
+set netX/ip <%= ip %>
+set netX/netmask <%= mask %>
+<% if gw.present? %>
+set netX/gateway <%= gw %>
+<% end %>
+ifstat net${idx}
+route
+
+<% else %>
 ifopen net${idx}
 # netX = last opened NIC
 set netX/ip <%= ip %>

--- a/app/views/foreman_bootdisk/host.erb
+++ b/app/views/foreman_bootdisk/host.erb
@@ -41,34 +41,38 @@ goto loop_success
 :loop_success
 echo Configuring net${idx} for static IP address <%= ip %>
 <% if interface.tag.present? && interface.attached_to.present? %>
-vcreate --tag <%= interface.tag %> net${idx}
-ifopen net${idx}-<%= interface.tag %>
-# netX = last opened NIC
-set netX/ip <%= ip %>
-set netX/netmask <%= mask %>
+     echo Configuring tagging for VLAN <%= interface.tag %>
+     echo WARNING: The following command (vcreate) will fail unless iPXE was
+     echo compiled with VLAN_CMD flag. See: https://ipxe.org/cmd/vcreate
+     vcreate --tag <%= interface.tag %> net${idx}
+     ifopen net${idx}-<%= interface.tag %>
+     # netX = last opened NIC
+     set netX/ip <%= ip %>
+     set netX/netmask <%= mask %>
 <% if gw.present? %>
-set netX/gateway <%= gw %>
+     set netX/gateway <%= gw %>
 <% end %>
-ifstat net${idx}
-route
+     ifstat net${idx}
+     route
 
 <% else %>
-ifopen net${idx}
-# netX = last opened NIC
-set netX/ip <%= ip %>
-set netX/netmask <%= mask %>
+     ifopen net${idx}
+     # netX = last opened NIC
+     set netX/ip <%= ip %>
+     set netX/netmask <%= mask %>
 <% if gw.present? %>
-set netX/gateway <%= gw %>
+     set netX/gateway <%= gw %>
 <% end %>
-ifstat net${idx}
-route
+     ifstat net${idx}
+     route
+<% end %>
 
 # Note: When multiple DNS servers are specified, only the first
 # server will be used. See: http://ipxe.org/cfg/dns
 <% if dns.present? -%>
-echo Using DNS <%= dns %>
-set dns <%= dns %>
-set domain <%= interface.domain.to_s %>
+     echo Using DNS <%= dns %>
+     set dns <%= dns %>
+     set domain <%= interface.domain.to_s %>
 <% end %>
 
 # Chainload from Foreman rather than embedding OS info here, so the behaviour


### PR DESCRIPTION
Using this updated template we will be able to provision the host on the VLAN tagged network.

We have to compile the new IPXE template with vcreate command --> https://ipxe.org/cmd/vcreate