### PR TITLE
Fixes #27668 - Allow bootdisk_build? in safemode

### DIFF
--- a/lib/foreman_bootdisk/engine.rb
+++ b/lib/foreman_bootdisk/engine.rb
@@ -53,7 +53,7 @@ module ForemanBootdisk
         apipie_documented_controllers ["#{ForemanBootdisk::Engine.root}/app/controllers/foreman_bootdisk/api/v2/*.rb"]
         provision_method 'bootdisk', N_('Boot disk based')
         template_labels 'Bootdisk' => N_('Boot disk embedded template')
-        allowed_template_helpers :bootdisk_chain_url, :bootdisk_raise
+        allowed_template_helpers :bootdisk_chain_url, :bootdisk_raise, :bootdisk_build?
       end
     end
 


### PR DESCRIPTION
We had merged this previously https://github.com/theforeman/foreman/pull/6989
But then reverted since method should be white listed by the plugin itself.

This change should do the job.