### PR TITLE
Fixes #28990 - Add description to plugin roles

### DIFF
--- a/lib/foreman_bootdisk/engine.rb
+++ b/lib/foreman_bootdisk/engine.rb
@@ -46,7 +46,7 @@ module ForemanBootdisk
                                          'foreman_bootdisk/api/v2/subnet_disks': [:subnet]
         end
 
-        role 'Boot disk access', [:download_bootdisk]
+        role 'Boot disk access', [:download_bootdisk], 'Role granting permissions to download bootdisks'
 
         add_all_permissions_to_default_roles
 


### PR DESCRIPTION
PR is part of  [Add default descriptions to all roles added from plugins](https://projects.theforeman.org/issues/28936) task.