### PR TITLE
Detach ISO after build

### DIFF
--- a/app/models/concerns/foreman_bootdisk/compute_resources/vmware.rb
+++ b/app/models/concerns/foreman_bootdisk/compute_resources/vmware.rb
@@ -36,9 +36,18 @@ module ForemanBootdisk
           'instance_uuid' => vm_uuid,
           'iso' => "foreman_isos/#{iso}",
           'datastore' => bootdisk_datastore(vm_uuid),
-          'start_connected' => false,
+          'start_connected' => true,
           'connected' => true,
           'allow_guest_control' => true
+        }
+        client.vm_reconfig_cdrom options
+      end
+
+      def iso_detach(vm_uuid)
+        options = {
+          'instance_uuid' => vm_uuid,
+          'start_connected' => false,
+          'connected' => false,
         }
         client.vm_reconfig_cdrom options
       end

--- a/app/models/concerns/foreman_bootdisk/orchestration/compute.rb
+++ b/app/models/concerns/foreman_bootdisk/orchestration/compute.rb
@@ -9,7 +9,6 @@ module ForemanBootdisk
 
       included do
         after_validation :queue_bootdisk_compute
-        after_build :rebuild_with_bootdisk
       end
 
       def bootdisk_isodir
@@ -21,15 +20,25 @@ module ForemanBootdisk
       end
 
       def queue_bootdisk_compute
-        return unless compute? && errors.empty? && new_record?
+        return unless compute? && errors.empty?
         return unless provision_method == 'bootdisk'
 
-        queue.create(name: _('Generating ISO image for %s') % self, priority: 5,
-                     action: [self, :setGenerateIsoImage])
-        queue.create(name: _('Upload ISO image to datastore for %s') % self, priority: 6,
-                     action: [self, :setIsoImage])
-        queue.create(name: _('Attach ISO image to CDROM drive for %s') % self, priority: 1001,
-                     action: [self, :setAttachIsoImage])
+        # We want to add our queue jobs only if really necessary:
+        #   - in case of starting to create a new host
+        #   - in case of a rebuild
+        if (old.nil? || !old.build?) && build?
+          queue.create(name: _('Generating ISO image for %s') % self, priority: 5,
+                       action: [self, :setGenerateIsoImage])
+          queue.create(name: _('Upload ISO image to datastore for %s') % self, priority: 6,
+                       action: [self, :setIsoImage])
+          queue.create(name: _('Attach ISO image to CDROM drive for %s') % self, priority: 1001,
+                       action: [self, :setAttachIsoImage])
+        # Detach ISO image when host sends 'built' HTTP POST request
+        elsif old&.build? && !build?
+          queue.create(name: _('Detach ISO image from CDROM drive for %s') % self, priority: 52,
+                       action: [self, :setDetachIsoImage])
+        end
+        true
       end
 
       def bootdisk_generate_iso_image
@@ -44,6 +53,10 @@ module ForemanBootdisk
 
       def bootdisk_attach_iso
         compute_resource.iso_attach(File.basename(bootdisk_isofile), uuid)
+      end
+
+      def bootdisk_detach_iso
+        compute_resource.iso_detach(uuid)
       end
 
       def setGenerateIsoImage
@@ -73,18 +86,14 @@ module ForemanBootdisk
 
       def delAttachIsoImage; end
 
-      def rebuild_with_bootdisk
-        return true unless bootdisk?
-
-        begin
-          bootdisk_generate_iso_image
-          bootdisk_upload_iso
-          bootdisk_attach_iso
-        rescue StandardError => e
-          Foreman::Logging.exception "Failed to rebuild Bootdisk image for #{name}", e, level: :error
-          return false
-        end
+      def setDetachIsoImage
+        logger.info format('Detaching ISO image from CDROM drive for %s', name)
+        bootdisk_detach_iso
+      rescue StandardError => e
+        failure format(_('Failed to detach ISO image from CDROM drive of instance %{name}: %{message}'), name: name, message: e.message), e
       end
+
+      def delDetachIsoImage; end
     end
   end
 end

--- a/test/unit/concerns/orchestration/compute_test.rb
+++ b/test/unit/concerns/orchestration/compute_test.rb
@@ -52,7 +52,7 @@ module ForemanBootdisk
       assert_not_includes tasks, "Detach ISO image from CDROM drive for #{@host.name}"
     end
 
-    test 'detaching the bootdisk should be done' do
+    test 'the iso should be detached when the host leaves build mode' do
       @host.stubs(:compute?).returns(true)
       old = stub()
       old.stubs(:build?).returns(true)


### PR DESCRIPTION
Detach the ISO Image after build. Attach the ISO image and mark with "start_connected" is necessary so that rebuild the host works (otherwise vmware would simply disconnect the iso if you reboot the host)