### PR TITLE
Fixes: #31585 iPXE ping gateway and name server

### DIFF
--- a/app/views/foreman_bootdisk/generic_efi_host.erb
+++ b/app/views/foreman_bootdisk/generic_efi_host.erb
@@ -44,6 +44,10 @@ net_bootp
 net_ls_addr
 net_ls_routes
 net_ls_dns
+echo Trying to ping proxy_httpboot_host: <%= proxy_httpboot_host %>
+ping --count 1 <%= proxy_httpboot_host %> || echo Ping to proxy_httpboot_host failed or ping command not available.
+echo Trying to ping proxy_template_host: <%= proxy_template_host %>
+ping --count 1 <%= proxy_template_host %> || echo Ping to proxy_template_host failed or ping command not available.
 sleep 5
 set root=(<%= proxy_proto %>,<%= proxy_httpboot_host %>:<%= proxy_port %>)
 # The variable will not survive configfile fetch, therefore absolute path

--- a/app/views/foreman_bootdisk/host.erb
+++ b/app/views/foreman_bootdisk/host.erb
@@ -58,6 +58,13 @@ set dns <%= dns %>
 set domain <%= interface.domain.to_s %>
 <% end %>
 
+echo Trying to ping Gateway: ${netX/gateway}
+ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
+<% if dns.present? -%>
+echo Trying to ping DNS: ${netX/dns}
+ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
+<% end %>
+
 # Chainload from Foreman rather than embedding OS info here, so the behaviour
 # is entirely dynamic.
 chain <%= bootdisk_chain_url %>


### PR DESCRIPTION
Attempt to ping critical network resources.  In theory when everything is working this should be transparent to the users.  If not, this will clearly identify what went wrong.