### PR TITLE
Fixes #32057 - delete old temporary bootdisks

### DIFF
--- a/app/services/foreman_bootdisk/iso_generator.rb
+++ b/app/services/foreman_bootdisk/iso_generator.rb
@@ -170,7 +170,8 @@ module ForemanBootdisk
       # Also we cannot rely on systemd-tmpfiles-clean as private temporary files are not subject
       # of scheduled cleanups. Let's clean bootdisks from prevous requests manually by finding
       # and deleting all directories created 30 minutes ago.
-      Rails.root.glob('tmp/bootdisk-iso-*').select { |f| File.ctime(f) < (Time.now.to_i - (60 * 30)) }.each { |f| FileUtils.rm_f(f) }
+      delete_older_than = Time.now.to_i - (60 * 30)
+      Rails.root.glob('tmp/bootdisk-iso-*').select { |f| File.ctime(f) < delete_older_than }.each { |f| FileUtils.rm_f(f) }
     end
 
     def self.build_mkiso_command(output_file:, source_directory:, extra_commands:)


### PR DESCRIPTION
This is because we now use PrivateTmp and systemd only cleans temp files after the service is stopped. But bootdisks are big (50MB each) and users will often fill their disks. The solution is to use permanent temp (/var/tmp) and clean them via systemd-tmpfiles.

A followup PRs into packaging will be associated with this PR, do not merge until packaging changes pass reviews.