### PR TITLE
fixes #32179 - Return code 404 instead of 500 missing subnet

### DIFF
--- a/app/controllers/foreman_bootdisk/api/v2/subnet_disks_controller.rb
+++ b/app/controllers/foreman_bootdisk/api/v2/subnet_disks_controller.rb
@@ -12,6 +12,7 @@ module ForemanBootdisk
           api_base_url '/bootdisk/api'
         end
 
+        rescue_from ActiveRecord::RecordNotFound, :with => :subnet_not_found
         before_action :find_resource, only: :subnet
 
         skip_after_action :log_response_body
@@ -41,6 +42,10 @@ module ForemanBootdisk
 
         def resource_scope
           Subnet.authorized('view_subnets')
+        end
+
+        def subnet_not_found
+          not_found ("Subnet not found by id '%s'") % params[:id]
         end
       end
     end

--- a/app/helpers/concerns/foreman_bootdisk/hosts_helper_ext.rb
+++ b/app/helpers/concerns/foreman_bootdisk/hosts_helper_ext.rb
@@ -26,7 +26,7 @@ module ForemanBootdisk
                 },
                 class: 'la'
               ),
-              content_tag(:li, '', class: 'divider'),
+              tag(:li, '', class: 'divider'),
               display_bootdisk_link_if_authorized(
                 _('Generic image'),
                 {
@@ -36,7 +36,7 @@ module ForemanBootdisk
                 class: 'la'
               ),
               display_bootdisk_for_subnet(host),
-              content_tag(:li, '', class: 'divider'),
+              tag(:li, '', class: 'divider'),
               display_bootdisk_link_if_authorized(
                 _('Help'), {
                   controller: 'foreman_bootdisk/disks',


### PR DESCRIPTION
Bootdisk should return code 404 for missing subnet