### PR TITLE
fixes #31726- Introducing disabling types of bootdisk

### DIFF
--- a/app/controllers/concerns/allowed_actions.rb
+++ b/app/controllers/concerns/allowed_actions.rb
@@ -1,0 +1,16 @@
+module AllowedActions
+  extend ActiveSupport::Concern
+
+  def bootdisk_type_allowed?(action = params[:action])
+    return true if Setting::Bootdisk.allowed_types&.include?(action)
+
+    message = _('This type of bootdisk is not allowed. Please contact administrator.')
+    if api_request?
+      render_error :custom_error, status: :unprocessable_entity, locals: { message: message}
+    else
+      error(message)
+      redirect_back(fallback_location: '/')
+    end
+    false
+  end
+end

--- a/app/controllers/foreman_bootdisk/api/v2/subnet_disks_controller.rb
+++ b/app/controllers/foreman_bootdisk/api/v2/subnet_disks_controller.rb
@@ -7,12 +7,14 @@ module ForemanBootdisk
     module V2
       class SubnetDisksController < ::Api::V2::BaseController
         include ::Api::Version2
+        include AllowedActions
 
         resource_description do
           api_base_url '/bootdisk/api'
         end
 
         rescue_from ActiveRecord::RecordNotFound, :with => :subnet_not_found
+        before_action :bootdisk_type_allowed?, only: :subnet
         before_action :find_resource, only: :subnet
 
         skip_after_action :log_response_body

--- a/app/controllers/foreman_bootdisk/disks_controller.rb
+++ b/app/controllers/foreman_bootdisk/disks_controller.rb
@@ -4,6 +4,9 @@ require 'uri'
 
 module ForemanBootdisk
   class DisksController < ::ApplicationController
+    include AllowedActions
+
+    before_action :bootdisk_type_allowed?, except: :help
     before_action :find_resource, only: %w[host full_host subnet]
 
     # as this engine is isolated, we need to include url helpers from core explicitly

--- a/app/helpers/concerns/foreman_bootdisk/hosts_helper_ext.rb
+++ b/app/helpers/concerns/foreman_bootdisk/hosts_helper_ext.rb
@@ -8,42 +8,7 @@ module ForemanBootdisk
           button_group(
             select_action_button(
               _('Boot disk'), { class: 'btn btn-group' },
-              display_bootdisk_link_if_authorized(
-                _("Host '%s' image") % host.name.split('.')[0],
-                {
-                  controller: 'foreman_bootdisk/disks',
-                  action: 'host',
-                  id: host
-                },
-                class: 'la'
-              ),
-              display_bootdisk_link_if_authorized(
-                _("Full host '%s' image") % host.name.split('.')[0],
-                {
-                  controller: 'foreman_bootdisk/disks',
-                  action: 'full_host',
-                  id: host
-                },
-                class: 'la'
-              ),
-              tag(:li, '', class: 'divider'),
-              display_bootdisk_link_if_authorized(
-                _('Generic image'),
-                {
-                  controller: 'foreman_bootdisk/disks',
-                  action: 'generic'
-                },
-                class: 'la'
-              ),
-              display_bootdisk_for_subnet(host),
-              tag(:li, '', class: 'divider'),
-              display_bootdisk_link_if_authorized(
-                _('Help'), {
-                  controller: 'foreman_bootdisk/disks',
-                  action: 'help'
-                },
-                class: 'la'
-              )
+              host_action_buttons(host)
             )
           )
         )
@@ -94,6 +59,67 @@ module ForemanBootdisk
 
     def bootdisk_authorized_for(options)
       User.current.allowed_to?(options)
+    end
+
+    def host_action_buttons(host)
+      actions = []
+
+      allowed_actions = Setting::Bootdisk.allowed_types
+      return '' unless allowed_actions
+
+      host_image_link = display_bootdisk_link_if_authorized(
+                          _("Host '%s' image") % host.name.split('.')[0],
+                          {
+                              controller: 'foreman_bootdisk/disks',
+                              action: 'host',
+                              id: host
+                          },
+                          class: 'la'
+                        )
+
+      full_host_image_link = display_bootdisk_link_if_authorized(
+                               _("Full host '%s' image") % host.name.split('.')[0],
+                               {
+                                   controller: 'foreman_bootdisk/disks',
+                                   action: 'full_host',
+                                   id: host
+                               },
+                               class: 'la'
+                             )
+
+      generic_image_link = display_bootdisk_link_if_authorized(
+                             _('Generic image'),
+                             {
+                                 controller: 'foreman_bootdisk/disks',
+                                 action: 'generic'
+                             },
+                             class: 'la'
+                           )
+
+      help_link = display_bootdisk_link_if_authorized(
+                    _('Help'),
+                    {
+                    controller: 'foreman_bootdisk/disks',
+                    action: 'help'
+                    },
+                    class: 'la'
+                  )
+
+      divider = tag(:li, '', class: 'divider')
+
+      actions << host_image_link if allowed_actions.include?('host')
+      actions << full_host_image_link if allowed_actions.include?('full_host')
+
+      subnet_link = display_bootdisk_for_subnet(host)
+      actions << divider if allowed_actions.include?('generic') || (allowed_actions.include?('subnet') && subnet_link.present?)
+
+      actions << generic_image_link if allowed_actions.include?('generic')
+      actions << subnet_link if allowed_actions.include?('subnet')
+
+      actions << divider
+      actions << help_link
+
+      actions
     end
   end
 end

--- a/app/models/setting/bootdisk.rb
+++ b/app/models/setting/bootdisk.rb
@@ -21,12 +21,21 @@ class Setting
         set('bootdisk_generic_efi_host_template', N_('Grub2 template to use for generic EFI host boot disks'),
             'Boot disk Grub2 EFI - generic host', N_('Generic Grub2 EFI image template'), nil, collection: templates),
         set('bootdisk_mkiso_command', N_('Command to generate ISO image, use genisoimage or mkisofs'), 'genisoimage', N_('ISO generation command')),
-        set('bootdisk_cache_media', N_('Installation media files will be cached for full host images'), true, N_('Installation media caching'))
+        set('bootdisk_cache_media', N_('Installation media files will be cached for full host images'), true, N_('Installation media caching')),
+        set('bootdisk_allowed_types', N_('List of allowed bootdisk types, remove type to disable it'), Setting::Bootdisk.bootdisk_types, N_('Allowed bootdisk types'))
       ]
     end
 
     def self.humanized_category
       N_('Boot disk')
+    end
+
+    def self.bootdisk_types
+      %w(generic host full_host subnet)
+    end
+
+    def self.allowed_types
+      Setting['bootdisk_allowed_types']
     end
   end
 end


### PR DESCRIPTION
This PR introduces ability to disable types of bootdisk in settings