### PR TITLE
fixes #10814, #11254 - Moving link to subnet page and introducing subnet disk controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The installation can continue on either the DHCP or static IP depending on how
 the OS iPXE template is configured, and could configure the assigned IP
 address statically for the installed system via the kickstart file.
 
-To generate the image from the web interface, view a host page, click the
+To generate the image from the web interface, view a subnet page, click the
 "Boot disk" button and select "Generic image".
 
 To generate using the Hammer CLI, install the [hammer_cli_foreman_bootdisk](https://github.com/theforeman/hammer_cli_foreman_bootdisk)
@@ -269,8 +269,7 @@ the "Templates" module enabled and configured.
 
 This image is generic for all hosts with a provisioning NIC on that subnet.
 
-To generate the image from the web interface, view a host page, click the
-"Boot disk" button and select "Subnet image".
+To generate the image from the web interface, view a subnet page and select "Subnet image" from subnet action buttons.
 
 To generate using the Hammer CLI, install the [hammer_cli_foreman_bootdisk](https://github.com/theforeman/hammer_cli_foreman_bootdisk)
 plugin and run:

--- a/app/controllers/foreman_bootdisk/disks_controller.rb
+++ b/app/controllers/foreman_bootdisk/disks_controller.rb
@@ -5,9 +5,11 @@ require 'uri'
 module ForemanBootdisk
   class DisksController < ::ApplicationController
     include AllowedActions
+    include PrettyError
 
     before_action :bootdisk_type_allowed?, except: :help
-    before_action :find_resource, only: %w[host full_host subnet]
+
+    before_action :find_resource, only: %w[host full_host]
 
     # as this engine is isolated, we need to include url helpers from core explicitly
     # to render help page layout
@@ -51,38 +53,12 @@ module ForemanBootdisk
       end
     end
 
-    def subnet
-      host = @disk
-      begin
-        subnet = host.try(:subnet) || raise(::Foreman::Exception.new(N_('Subnet is not assigned to the host %s'), host.name))
-        subnet.tftp || raise(::Foreman::Exception.new(N_('TFTP feature not enabled for subnet %s'), subnet.name))
-        subnet.httpboot || ForemanBootdisk.logger.warn('HTTPBOOT feature is not enabled for subnet %s, UEFI may not be available for bootdisk' % subnet.name)
-
-        tmpl_bios = ForemanBootdisk::Renderer.new.generic_template_render(subnet)
-        tmpl_efi = ForemanBootdisk::Renderer.new.generic_efi_template_render(subnet)
-      rescue StandardError => e
-        error_rendering(e)
-        redirect_back(fallback_location: '/')
-        return
-      end
-
-      ForemanBootdisk::ISOGenerator.generate(ipxe: tmpl_bios, grub: tmpl_efi) do |iso|
-        send_file(iso, filename: "bootdisk_subnet_#{subnet.name}.iso")
-      end
-    end
-
     def help; end
 
     private
 
     def resource_scope(_controller = controller_name)
       Host::Managed.authorized(:view_hosts)
-    end
-
-    def error_rendering(exception)
-      msg = _('Failed to render boot disk template')
-      error("#{msg}: #{exception.message}")
-      ::Foreman::Logging.exception(msg, exception)
     end
   end
 end

--- a/app/controllers/foreman_bootdisk/subnet_disks_controller.rb
+++ b/app/controllers/foreman_bootdisk/subnet_disks_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module ForemanBootdisk
+  class SubnetDisksController < ::ApplicationController
+    include PrettyError
+
+    before_action :find_resource, only: :subnet
+
+    # as this engine is isolated, we need to include url helpers from core explicitly
+    # to render help page layout
+    include Rails.application.routes.url_helpers
+
+    def subnet
+      begin
+        @subnet.tftp || raise(::Foreman::Exception.new(N_('TFTP feature not enabled for subnet %s'), @subnet.name))
+        @subnet.httpboot || ForemanBootdisk.logger.warn('HTTPBOOT feature is not enabled for subnet %s, UEFI may not be available for bootdisk' % @subnet.name)
+
+        tmpl_bios = ForemanBootdisk::Renderer.new.generic_template_render(@subnet)
+        tmpl_efi = ForemanBootdisk::Renderer.new.generic_efi_template_render(@subnet)
+      rescue StandardError => e
+        error_rendering(e)
+        redirect_back(fallback_location: '/')
+        return
+      end
+
+      ForemanBootdisk::ISOGenerator.generate(ipxe: tmpl_bios, grub: tmpl_efi) do |iso|
+        send_file(iso, filename: "bootdisk_subnet_#{@subnet.name}.iso")
+      end
+    end
+
+    private
+
+    def resource_scope(_controller = controller_name)
+      Subnet.authorized(:view_subnets)
+    end
+
+    def find_resource
+      @subnet = Subnet.find(params[:id])
+    end
+  end
+end

--- a/app/helpers/bootdisk_links_helper.rb
+++ b/app/helpers/bootdisk_links_helper.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module BootdiskLinksHelper
+  # Core Foreman helpers can't look up a URL against a mounted engine
+  def display_bootdisk_link_if_authorized(name, options = {}, html_options = {})
+    if bootdisk_authorized_for(options)
+      link_to(name, bootdisk_url(options), html_options)
+    else
+      ''
+    end
+  end
+
+  def bootdisk_url(options)
+    ForemanBootdisk::Engine.routes.url_for(options.merge(only_path: true, script_name: foreman_bootdisk_path))
+  end
+
+  def bootdisk_authorized_for(options)
+    User.current.allowed_to?(options)
+  end
+
+  def divider
+    tag(:li, class: 'divider')
+  end
+
+  def bootdisk_help_link
+    display_bootdisk_link_if_authorized(
+      _('Boot disk Help'),
+    {
+        controller: 'foreman_bootdisk/disks',
+        action: 'help'
+      },
+      class: 'la'
+    )
+  end
+
+  def bootdisk_title_action_buttons(actions)
+    title_actions(
+      button_group(
+        select_action_button(
+          _('Boot disk'), { class: 'btn btn-group' },
+          actions
+        )
+      )
+    )
+  end
+end

--- a/app/helpers/concerns/foreman_bootdisk/hosts_helper_ext.rb
+++ b/app/helpers/concerns/foreman_bootdisk/hosts_helper_ext.rb
@@ -2,16 +2,11 @@
 
 module ForemanBootdisk
   module HostsHelperExt
+    include BootdiskLinksHelper
+
     def host_title_actions(host)
       if host.bootdisk_downloadable?
-        title_actions(
-          button_group(
-            select_action_button(
-              _('Boot disk'), { class: 'btn btn-group' },
-              host_action_buttons(host)
-            )
-          )
-        )
+        bootdisk_title_action_buttons(host_action_buttons(host))
       else
         bootdisk_button_disabled(host)
       end
@@ -69,55 +64,30 @@ module ForemanBootdisk
 
       host_image_link = display_bootdisk_link_if_authorized(
                           _("Host '%s' image") % host.name.split('.')[0],
-                          {
-                              controller: 'foreman_bootdisk/disks',
-                              action: 'host',
-                              id: host
+                        {
+                            controller: 'foreman_bootdisk/disks',
+                            action: 'host',
+                            id: host
                           },
                           class: 'la'
                         )
 
       full_host_image_link = display_bootdisk_link_if_authorized(
                                _("Full host '%s' image") % host.name.split('.')[0],
-                               {
-                                   controller: 'foreman_bootdisk/disks',
-                                   action: 'full_host',
-                                   id: host
+                             {
+                                 controller: 'foreman_bootdisk/disks',
+                                 action: 'full_host',
+                                 id: host
                                },
                                class: 'la'
                              )
 
-      generic_image_link = display_bootdisk_link_if_authorized(
-                             _('Generic image'),
-                             {
-                                 controller: 'foreman_bootdisk/disks',
-                                 action: 'generic'
-                             },
-                             class: 'la'
-                           )
-
-      help_link = display_bootdisk_link_if_authorized(
-                    _('Help'),
-                    {
-                    controller: 'foreman_bootdisk/disks',
-                    action: 'help'
-                    },
-                    class: 'la'
-                  )
-
-      divider = tag(:li, '', class: 'divider')
-
       actions << host_image_link if allowed_actions.include?('host')
       actions << full_host_image_link if allowed_actions.include?('full_host')
 
-      subnet_link = display_bootdisk_for_subnet(host)
-      actions << divider if allowed_actions.include?('generic') || (allowed_actions.include?('subnet') && subnet_link.present?)
+      actions << divider if (host_image_link.present? && allowed_actions.include?('host')) || (full_host_image_link.present? && allowed_actions.include?('full_host'))
 
-      actions << generic_image_link if allowed_actions.include?('generic')
-      actions << subnet_link if allowed_actions.include?('subnet')
-
-      actions << divider
-      actions << help_link
+      actions << bootdisk_help_link
 
       actions
     end

--- a/app/helpers/concerns/foreman_bootdisk/pretty_error.rb
+++ b/app/helpers/concerns/foreman_bootdisk/pretty_error.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ForemanBootdisk
+  module PrettyError
+    extend ActiveSupport::Concern
+
+    def error_rendering(exception)
+      msg = _('Failed to render boot disk template')
+      error("#{msg}: #{exception.message}")
+      ::Foreman::Logging.exception(msg, exception)
+    end
+  end
+end

--- a/app/helpers/concerns/foreman_bootdisk/subnets_helper_ext.rb
+++ b/app/helpers/concerns/foreman_bootdisk/subnets_helper_ext.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module ForemanBootdisk
+  module SubnetsHelperExt
+    include BootdiskLinksHelper
+
+    def display_bootdisk_for_subnet(subnet)
+      if (proxy = subnet.tftp || subnet.httpboot) && proxy.has_feature?('Templates') && Setting::Bootdisk.allowed_types.include?('subnet')
+        display_bootdisk_link_if_authorized(
+            _("Subnet generic image"), {
+            controller: 'foreman_bootdisk/subnet_disks',
+            action: 'subnet',
+            id: subnet.id
+        },
+            class: 'la'
+        )
+      else
+        ''
+      end
+    end
+
+    def display_bootdisk_title_buttons
+
+      actions = []
+
+      generic_image_link = display_bootdisk_link_if_authorized(
+                             _('Generic image'),
+                           {
+                               controller: 'foreman_bootdisk/disks',
+                               action: 'generic'
+                             },
+                             class: 'la'
+                           )
+
+      if Setting::Bootdisk.allowed_types&.include?('generic')
+        actions << generic_image_link
+        actions << divider
+      end
+
+      actions << bootdisk_help_link
+
+      bootdisk_title_action_buttons(actions)
+    end
+  end
+end

--- a/app/views/foreman_bootdisk/disks/help.html.erb
+++ b/app/views/foreman_bootdisk/disks/help.html.erb
@@ -9,7 +9,12 @@
     <%= _('All images are usable as either ISOs or as disk images, including being written to a USB disk with `dd`.') %>
   </p>
 
-  <h2><%= _('Host image') %></h2>
+  <h2><%= _('Host images') %></h2>
+  <p>
+    <%= _('These images are used for host. You can find them at host detail page.') %>
+  </p>
+
+  <h3><%= _('Host image') %></h3>
   <p>
     <%= _("Per-host images contain data about a particular host registered in Foreman and set up fully static networking, avoiding the requirement for DHCP.  After networking is configured, they chainload from Foreman, picking up the current OS configuration and build state from the server.") %>
   </p>
@@ -17,12 +22,17 @@
     <%= _("Once chainloaded, the OS bootloader and installer are downloaded directly from the installation media configured in Foreman, and the provisioning script (kickstart/preseed) is downloaded from Foreman.") %>
   </p>
 
-  <h2><%= _('Full host image') %></h2>
+  <h3><%= _('Full host image') %></h3>
   <p>
     <%= _('A variant of the per-host image which contains the OS bootloader embedded inside the disk.  This may be useful if chainloading fails on certain hardware, but has the downside that the image must be regenerated for any change in the OS, bootloader or PXELinux templates.') %>
   </p>
 
-  <h2><%= _('Generic image') %></h2>
+  <h2><%= _('Generic images') %></h2>
+  <p>
+    <%= _('These images are more generic than previous images. You can find them at subnet index page.') %>
+  </p>
+
+  <h3><%= _('Generic image') %></h3>
   <p>
     <%= _('Generic images are a reusable disk image that works for any host registered in Foreman.  It requires a basic DHCP and DNS service to function and contact the server, but does not require DHCP reservations or static IP addresses.') %>
   </p>
@@ -30,7 +40,7 @@
     <%= _('The OS install continues using the installation media configured in Foreman, and it will typically configure static networking, depending on how the OS iPXE template is configured.') %>
   </p>
 
-  <h2><%= _('Subnet image') %></h2>
+  <h3><%= _('Subnet image') %></h3>
   <p>
     <%= _('Subnet images are similar to generic images, but chain-loading is done via the TFTP Smart Proxy assigned to the Subnet of the host. The smart proxy must have the "Templates" module enabled and configured.') %>
   </p>

--- a/app/views/subnets/_bootdisk_action_buttons.erb
+++ b/app/views/subnets/_bootdisk_action_buttons.erb
@@ -1,0 +1,1 @@
+<%= display_bootdisk_for_subnet(subject) %>

--- a/app/views/subnets/_bootdisk_title_buttons.erb
+++ b/app/views/subnets/_bootdisk_title_buttons.erb
@@ -1,0 +1,1 @@
+<%= display_bootdisk_title_buttons %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ ForemanBootdisk::Engine.routes.draw do
     constraints(id: %r{[^/]+}) do
       get 'hosts/:id', on: :collection, to: 'disks#host'
       get 'full_hosts/:id', on: :collection, to: 'disks#full_host'
-      get 'subnet/:id', on: :collection, to: 'disks#subnet'
+      get 'subnet/:id', on: :collection, to: 'subnet_disks#subnet'
     end
   end
 

--- a/lib/foreman_bootdisk/version.rb
+++ b/lib/foreman_bootdisk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ForemanBootdisk
-  VERSION = '17.0.2'
+  VERSION = '18.0.0'
 end

--- a/test/functional/foreman_bootdisk/disks_controller_test.rb
+++ b/test/functional/foreman_bootdisk/disks_controller_test.rb
@@ -35,16 +35,6 @@ class ForemanBootdisk::DisksControllerTest < ActionController::TestCase
     tmp.unlink
   end
 
-  def perform_subnet_generate
-    tmp = create_tempfile
-    ForemanBootdisk::ISOGenerator.expects(:generate).yields(create_tempfile.path)
-    get :subnet, params: { id: @host.name }, session: set_session_user
-    assert_empty flash[:error]
-    assert_response :success
-  ensure
-    tmp.unlink
-  end
-
   describe '#generic with TFTP' do
     setup :setup_subnet_with_tftp
     setup :setup_host
@@ -59,10 +49,6 @@ class ForemanBootdisk::DisksControllerTest < ActionController::TestCase
 
     test 'should generate full host image' do
       perform_full_host_generate
-    end
-
-    test 'should generate subnet image' do
-      perform_subnet_generate
     end
   end
 
@@ -80,23 +66,6 @@ class ForemanBootdisk::DisksControllerTest < ActionController::TestCase
 
     test 'should generate full host image' do
       perform_full_host_generate
-    end
-
-    test 'should generate subnet image' do
-      perform_subnet_generate
-    end
-  end
-
-  describe '#host without tftp' do
-    setup :setup_referer
-    setup :setup_org_loc
-    setup :setup_subnet_no_tftp
-    setup :setup_host
-
-    test 'should not generate subnet image' do
-      get :subnet, params: { id: @host.name }, session: set_session_user
-      assert_match(/Failed.*: TFTP feature not enabled/, flash[:error])
-      assert_response :redirect
     end
   end
 

--- a/test/functional/foreman_bootdisk/subnet_disks_controller_test.rb
+++ b/test/functional/foreman_bootdisk/subnet_disks_controller_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+class ForemanBootdisk::SubnetDisksControllerTest < ActionController::TestCase
+  include ForemanBootdiskTestHelper
+  setup :setup_bootdisk
+  setup :setup_referer
+  setup :setup_org_loc
+
+  def perform_subnet_generate
+    tmp = create_tempfile
+    ForemanBootdisk::ISOGenerator.expects(:generate).yields(create_tempfile.path)
+    get :subnet, params: { id: @subnet.id }, session: set_session_user
+    assert_empty flash[:error]
+    assert_response :success
+  ensure
+    tmp.unlink
+  end
+
+  describe '#generic with TFTP' do
+    setup :setup_subnet_with_tftp
+    setup :setup_host
+
+    test 'should generate subnet image' do
+      perform_subnet_generate
+    end
+  end
+
+  describe '#subnet_host with TFTP and HTTPBOOT' do
+    setup :setup_subnet_with_tftp_httpboot_template
+    setup :setup_host
+
+    test 'should generate subnet image' do
+      perform_subnet_generate
+    end
+  end
+
+  describe '#host without tftp' do
+    setup :setup_referer
+    setup :setup_org_loc
+    setup :setup_subnet_no_tftp
+    setup :setup_host
+
+    test 'should not generate subnet image' do
+      get :subnet, params: { id: @subnet.id }, session: set_session_user
+      assert_match(/Failed.*: TFTP feature not enabled/, flash[:error])
+      assert_response :redirect
+    end
+  end
+end


### PR DESCRIPTION


This PR solves two big problems in bootdisk plugin. Both of them are tied with subnet. The first one moves button for download subnet image on subnet page. That's a huge improvement because right know this button lays at the detail of host page. This has historical reason becuase subnet image generation has been at disks controller for host. This is a second problem, so the logic of generation of subnet image is moves to separate controller.