### PR TITLE
fixes #31674 - Updating token expiration when bootdisk is downloaded

### DIFF
--- a/test/functional/foreman_bootdisk/disks_controller_test.rb
+++ b/test/functional/foreman_bootdisk/disks_controller_test.rb
@@ -69,6 +69,27 @@ class ForemanBootdisk::DisksControllerTest < ActionController::TestCase
     end
   end
 
+  describe '#host without tftp' do
+    setup :setup_referer
+    setup :setup_org_loc
+    setup :setup_subnet_no_tftp
+    setup :setup_host
+
+    test 'should prolong token for host image' do
+      Setting[:token_duration] = 60
+      @host.set_token
+      past = Time.now
+      assert @host.token.expires > past
+      travel_to(past + 2.hours)
+      assert @host.token_expired?
+
+      perform_full_host_generate
+
+      assert_equal @host.token_expired?, true
+      assert @host.token.expires > past
+    end
+  end
+
   test 'should render help' do
     get :help, session: set_session_user
     assert_response :success


### PR DESCRIPTION
This PR tries to solves problem where Bootdisk produces useless bootdisk
by hardcoding tokens after it's expiration. So before the bootdisk is
downloaded, the token for host is updated with new expiration time.