### PR TITLE
fixes #32400 - Adding explanation of disabled bootdisks

### DIFF
--- a/app/controllers/foreman_bootdisk/disks_controller.rb
+++ b/app/controllers/foreman_bootdisk/disks_controller.rb
@@ -7,6 +7,8 @@ module ForemanBootdisk
     include AllowedActions
     include PrettyError
 
+    helper DiskHelper
+
     before_action :bootdisk_type_allowed?, except: :help
 
     before_action :find_resource, only: %w[host full_host]

--- a/app/helpers/disk_helper.rb
+++ b/app/helpers/disk_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module DiskHelper
+  def mark_disabled_bootdisk_type(type)
+    return '' if Setting::Bootdisk.allowed_types&.include?(type)
+    '*'
+  end
+end

--- a/app/views/foreman_bootdisk/disks/help.html.erb
+++ b/app/views/foreman_bootdisk/disks/help.html.erb
@@ -14,7 +14,7 @@
     <%= _('These images are used for host. You can find them at host detail page.') %>
   </p>
 
-  <h3><%= _('Host image') %></h3>
+  <h3><%= _('Host image') %><%= mark_disabled_bootdisk_type('host') %></h3>
   <p>
     <%= _("Per-host images contain data about a particular host registered in Foreman and set up fully static networking, avoiding the requirement for DHCP.  After networking is configured, they chainload from Foreman, picking up the current OS configuration and build state from the server.") %>
   </p>
@@ -22,7 +22,7 @@
     <%= _("Once chainloaded, the OS bootloader and installer are downloaded directly from the installation media configured in Foreman, and the provisioning script (kickstart/preseed) is downloaded from Foreman.") %>
   </p>
 
-  <h3><%= _('Full host image') %></h3>
+  <h3><%= _('Full host image') %><%= mark_disabled_bootdisk_type('full_host') %></h3>
   <p>
     <%= _('A variant of the per-host image which contains the OS bootloader embedded inside the disk.  This may be useful if chainloading fails on certain hardware, but has the downside that the image must be regenerated for any change in the OS, bootloader or PXELinux templates.') %>
   </p>
@@ -32,7 +32,7 @@
     <%= _('These images are more generic than previous images. You can find them at subnet index page.') %>
   </p>
 
-  <h3><%= _('Generic image') %></h3>
+  <h3><%= _('Generic image') %><%= mark_disabled_bootdisk_type('generic') %></h3>
   <p>
     <%= _('Generic images are a reusable disk image that works for any host registered in Foreman.  It requires a basic DHCP and DNS service to function and contact the server, but does not require DHCP reservations or static IP addresses.') %>
   </p>
@@ -40,11 +40,13 @@
     <%= _('The OS install continues using the installation media configured in Foreman, and it will typically configure static networking, depending on how the OS iPXE template is configured.') %>
   </p>
 
-  <h3><%= _('Subnet image') %></h3>
+  <h3><%= _('Subnet image') %><%= mark_disabled_bootdisk_type('subnet') %></h3>
   <p>
     <%= _('Subnet images are similar to generic images, but chain-loading is done via the TFTP Smart Proxy assigned to the Subnet of the host. The smart proxy must have the "Templates" module enabled and configured.') %>
   </p>
   <p>
     <%= _('This image is generic for all hosts with a provisioning NIC on that subnet.') %>
   </p>
+
+  <p><%= _('* - These bootdisk types were disabled, you can enable them in Administer - Settings.') %></p>
 </div>


### PR DESCRIPTION
In the settings of Bootdisk plugin, you can disable types of boodisks. There wasn't any explanation and simple way how to distinguish what's disabled. This PR adds asterisk after name of type at the bootdisk help page and adds also what does it mean at the same page.