### PR TITLE
fixes #31673 - Fixing error handling when host is not in build mode

### DIFF
--- a/app/controllers/foreman_bootdisk/api/v2/disks_controller.rb
+++ b/app/controllers/foreman_bootdisk/api/v2/disks_controller.rb
@@ -37,8 +37,13 @@ module ForemanBootdisk
           host = @disk
           if params[:full]
             return unless bootdisk_type_allowed?('full_host')
-            ForemanBootdisk::ISOGenerator.generate_full_host(host) do |iso|
-              send_file(iso, filename: "#{host.name}#{ForemanBootdisk::ISOGenerator.token_expiry(host)}.iso")
+            begin
+              ForemanBootdisk::ISOGenerator.generate_full_host(host) do |iso|
+                send_file(iso, filename: "#{host.name}#{ForemanBootdisk::ISOGenerator.token_expiry(host)}.iso")
+              end
+            rescue ::Foreman::Exception => e
+              raise e unless e.code == 'ERF42-2893'
+              render_error json: { error: _('Host is not in build mode')}, status: :method_not_allowed
             end
           else
             return unless bootdisk_type_allowed?

--- a/app/controllers/foreman_bootdisk/disks_controller.rb
+++ b/app/controllers/foreman_bootdisk/disks_controller.rb
@@ -54,9 +54,14 @@ module ForemanBootdisk
       host = @disk
 
       prolong_token(host)
-
-      ForemanBootdisk::ISOGenerator.generate_full_host(host) do |iso|
-        send_file(iso, filename: "#{host.name}#{ForemanBootdisk::ISOGenerator.token_expiry(host)}.iso")
+      begin
+        ForemanBootdisk::ISOGenerator.generate_full_host(host) do |iso|
+          send_file(iso, filename: "#{host.name}#{ForemanBootdisk::ISOGenerator.token_expiry(host)}.iso")
+        end
+      rescue ::Foreman::Exception => e
+        raise e unless e.code == 'ERF42-2893'
+        error _('Host is not in build mode.')
+        redirect_back(fallback_location: '/')
       end
     end
 

--- a/app/helpers/concerns/foreman_bootdisk/hosts_helper_ext.rb
+++ b/app/helpers/concerns/foreman_bootdisk/hosts_helper_ext.rb
@@ -82,8 +82,26 @@ module ForemanBootdisk
                                class: 'la'
                              )
 
+      full_host_blind_link = if bootdisk_authorized_for({controller: 'foreman_bootdisk/disks', action: 'full_host', id: host})
+                               link_to(_("Full host '%s' image") % host.name.split('.')[0],
+                                       '#',
+                                       class: 'la btn btn-info',
+                                       disabled: true,
+                                       title: _('Host is not in build mode')
+                               )
+                             else
+                               ''
+                             end
+
       actions << host_image_link if allowed_actions.include?('host')
-      actions << full_host_image_link if allowed_actions.include?('full_host')
+      if allowed_actions.include?('full_host')
+        if host.build?
+          actions << full_host_image_link
+        else
+          actions << full_host_blind_link
+        end
+      end
+
 
       actions << divider if (host_image_link.present? && allowed_actions.include?('host')) || (full_host_image_link.present? && allowed_actions.include?('full_host'))
 


### PR DESCRIPTION
With current implementation, it's possible to download a bootdisk full host even for hosts that are not in build mode. So this scenario ends with the Foreman error every time for hosts that are not in build mode. This PR handles this error much better. It adds some error messages, refuses serving an image for API requests and also disables button for download.