### PR TITLE
Fix migration: Invalid single-table inheritance

### DIFF
--- a/db/migrate/20140522185700_change_templatekind_to_bootdisk.rb
+++ b/db/migrate/20140522185700_change_templatekind_to_bootdisk.rb
@@ -1,22 +1,14 @@
 # frozen_string_literal: true
 
 class ChangeTemplatekindToBootdisk < ActiveRecord::Migration[4.2]
-  class FakeConfigTemplate < ApplicationRecord
-    self.table_name = if ActiveRecord::Base.connection.migration_context.get_all_versions.include?(20_150_514_072_626)
-                        'templates'
-                      else
-                        'config_templates'
-                      end
-  end
-
   def self.up
     kind = TemplateKind.where(name: 'Bootdisk').first_or_create
 
     tmpl_h = Setting.find_by(name: 'bootdisk_host_template').try(:value)
     tmpl_g = Setting.find_by(name: 'bootdisk_generic_host_template').try(:value)
 
-    (FakeConfigTemplate.unscoped.where('name LIKE ?', '%Boot disk%') |
-      FakeConfigTemplate.unscoped.where(name: [tmpl_h, tmpl_g].compact)).each do |tmpl|
+    (Template.unscoped.where('name LIKE ?', '%Boot disk%') |
+      Template.unscoped.where(name: [tmpl_h, tmpl_g].compact)).each do |tmpl|
       tmpl.update_attribute(:template_kind_id, kind.id)
     end
   end
@@ -26,6 +18,6 @@ class ChangeTemplatekindToBootdisk < ActiveRecord::Migration[4.2]
     new_kind = TemplateKind.find_by(name: 'iPXE')
     return unless old_kind.present? && new_kind.present?
 
-    FakeConfigTemplate.unscoped.where(template_kind_id: old_kind.id).update_all(template_kind_id: new_kind.id)
+    Template.unscoped.where(template_kind_id: old_kind.id).update_all(template_kind_id: new_kind.id)
   end
 end


### PR DESCRIPTION
Given that the `FakeConfigTemplate` class was introduced for foreman<1.9, I believe it is save to remove it now.

Partly reverts 1e744832ea6f1f3eb19a2f2cfdad586a4bdf013f