### PR TITLE
Use reusable GitHub Actions

### DIFF
--- a/.github/workflows/ruby_ci.yaml
+++ b/.github/workflows/ruby_ci.yaml
@@ -4,23 +4,18 @@ on:
   push:
     branches:
       - master
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 env:
   RAILS_ENV: test
   DATABASE_URL: postgresql://postgres:@localhost/test
   DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: true
 jobs:
   rubocop:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-          bundler-cache: true
-      - name: Run rubocop
-        if: github.event_name != 'push'
-        run: bundle exec rubocop --parallel --format github
+    uses: theforeman/actions/.github/workflows/rubocop.yml@v0
+    with:
+      command: bundle exec rubocop --parallel --format github
   test_ruby:
     runs-on: ubuntu-latest
     needs: rubocop

--- a/foreman_bootdisk.gemspec
+++ b/foreman_bootdisk.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.5'
 
   s.add_development_dependency 'theforeman-rubocop'
-  s.add_development_dependency 'webmock'
 end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'webmock/minitest'
-require 'webmock'
 
 module ForemanBootdiskTestHelper
   def create_tempfile


### PR DESCRIPTION
This saves on duplication.

Right now the command must be overridden since the default does not pass --parallel --format github.

Webmock is removed since it's redundant and saves on Rubocop installation time.