### PR TITLE
Version 20.0

### DIFF
--- a/lib/foreman_bootdisk/version.rb
+++ b/lib/foreman_bootdisk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ForemanBootdisk
-  VERSION = '19.0.5'
+  VERSION = '20.0.0'
 end


### PR DESCRIPTION
Since require_foreman was changed earlier,
we actually need to bump this plugin's major version.