### PR TITLE
Fixes #35090 - Fix routes

### DIFF
--- a/app/controllers/foreman_bootdisk/api/v2/disks_controller.rb
+++ b/app/controllers/foreman_bootdisk/api/v2/disks_controller.rb
@@ -9,10 +9,6 @@ module ForemanBootdisk
         include ::Api::Version2
         include AllowedActions
 
-        resource_description do
-          api_base_url '/bootdisk/api'
-        end
-
         before_action :bootdisk_type_allowed?, only: :generic
         before_action :find_resource, only: :host
         skip_after_action :log_response_body

--- a/app/controllers/foreman_bootdisk/api/v2/subnet_disks_controller.rb
+++ b/app/controllers/foreman_bootdisk/api/v2/subnet_disks_controller.rb
@@ -9,10 +9,6 @@ module ForemanBootdisk
         include ::Api::Version2
         include AllowedActions
 
-        resource_description do
-          api_base_url '/bootdisk/api'
-        end
-
         rescue_from ActiveRecord::RecordNotFound, :with => :subnet_not_found
         before_action :bootdisk_type_allowed?, only: :subnet
         before_action :find_resource, only: :subnet

--- a/app/controllers/foreman_bootdisk/disks_controller.rb
+++ b/app/controllers/foreman_bootdisk/disks_controller.rb
@@ -121,7 +121,7 @@ module ForemanBootdisk
         disable_full_host = action == 'full_host' && !host.build?
         actions << {
           title: title,
-          link: "/bootdisk/disks/#{action}s/#{host.id}",
+          link: "/disks/#{action}s/#{host.id}",
           disabled:  disable_full_host ? true : false,
           description: disable_full_host ? _('Host is not in build mode') : nil,
           icon: action,
@@ -131,7 +131,7 @@ module ForemanBootdisk
 
       allowed.push({
         title: _('Boot disk help'),
-        link: '/bootdisk/disks/help',
+        link: '/disks/help',
         icon: 'help'
       })
     end

--- a/webpack/src/extensions/host/HostBootdiskButtons.js
+++ b/webpack/src/extensions/host/HostBootdiskButtons.js
@@ -46,7 +46,7 @@ const HostBootdiskButtons = () => {
     dispatch(
       get({
         key: HOST_BOOTDISK_BUTTONS_REQUEST_KEY,
-        url: foremanUrl(`/bootdisk/disks/bootdisk_options/${hostId}`),
+        url: foremanUrl(`/disks/bootdisk_options/${hostId}`),
       })
     );
   }, [dispatch, hostId]);


### PR DESCRIPTION
After https://github.com/theforeman/foreman_bootdisk/pull/122 the plugin got broken a bit due to https://github.com/stejskalleos/foreman_bootdisk/blob/4be52bfcda948db427e9615aa11f6f536012d568/config/routes/mount_engine.rb#L4 change.

This patch simply changes old route usages to the new ones. As a side effect for users, if they use direct API calls, they might not be able to use it anymore since the docs got updated (not tested, but this often happens if hammer starts to fail).

UPD: this should fix both UI and API/hammer parts.