### PR TITLE
Fixes #35282 - populate templates description from metadata

### DIFF
--- a/db/seeds.d/50-bootdisk_templates.rb
+++ b/db/seeds.d/50-bootdisk_templates.rb
@@ -21,6 +21,10 @@ def ensure_bootdisk_template(name, content)
   tmpl.locked = true
   tmpl.organizations = Organization.unscoped.all if SETTINGS[:organizations_enabled]
   tmpl.locations = Location.unscoped.all if SETTINGS[:locations_enabled]
+
+  metadata = Template.parse_metadata(content)
+  tmpl.description = metadata['description']
+
   tmpl.save!(validate: false) if tmpl.changes.present?
 end
 


### PR DESCRIPTION
This PR applies a simpler solution for the missing description issue(compared to this [PR](https://github.com/theforeman/foreman_bootdisk/pull/126)), and it is intended for Satellite 6.12.