### PR TITLE
Fixes #35700 - bugfixes for API routes & subnets

### DIFF
--- a/app/controllers/foreman_bootdisk/api/v2/disks_controller.rb
+++ b/app/controllers/foreman_bootdisk/api/v2/disks_controller.rb
@@ -14,10 +14,10 @@ module ForemanBootdisk
         skip_after_action :log_response_body
 
         # no-op, but required for apipie documentation
-        api :GET, '', N_('Boot disks')
+        api :GET, '/bootdisk', N_('Boot disks')
         def index; end
 
-        api :GET, '/generic', N_('Download generic image')
+        api :GET, '/bootdisk/generic', N_('Download generic image')
         def generic
           # EFI not supported for iPXE generic bootdisk
           tmpl = ForemanBootdisk::Renderer.new.generic_template_render
@@ -26,7 +26,7 @@ module ForemanBootdisk
           end
         end
 
-        api :GET, '/hosts/:host_id', N_('Download host image')
+        api :GET, '/bootdisk/hosts/:host_id', N_('Download host image')
         param :full, :bool, required: false, desc: N_('True for full, false for basic reusable image')
         param :host_id, :identifier_dottable, required: true
         def host

--- a/app/controllers/foreman_bootdisk/api/v2/subnet_disks_controller.rb
+++ b/app/controllers/foreman_bootdisk/api/v2/subnet_disks_controller.rb
@@ -16,10 +16,10 @@ module ForemanBootdisk
         skip_after_action :log_response_body
 
         # no-op, but required for apipie documentation
-        api :GET, '', N_('Subnet boot disks')
+        api :GET, '/bootdisk', N_('Subnet boot disks')
         def index; end
 
-        api :GET, '/subnets/:subnet_id', N_('Download subnet generic image')
+        api :GET, '/bootdisk/subnets/:subnet_id', N_('Download subnet generic image')
         param :subnet_id, :identifier_dottable, required: true
         def subnet
           subnet = @subnet_disk

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,10 +14,12 @@ ForemanBootdisk::Engine.routes.draw do
 
   namespace :api, defaults: { format: 'json' } do
     scope '(:apiv)', module: :v2, defaults: { apiv: 'v2' }, apiv: /v1|v2/, constraints: ApiConstraints.new(version: 2, default: true) do
-      get 'generic', to: 'disks#generic'
-      constraints(id: %r{[^/]+}) do
-        get 'hosts/:id', to: 'disks#host'
-        get 'subnets/:id', to: 'subnet_disks#subnet'
+      scope :bootdisk do
+        get 'generic', to: 'disks#generic'
+        constraints(id: %r{[^/]+}) do
+          get 'hosts/:id', to: 'disks#host'
+          get 'subnets/:id', to: 'subnet_disks#subnet'
+        end
       end
     end
   end

--- a/lib/foreman_bootdisk/engine.rb
+++ b/lib/foreman_bootdisk/engine.rb
@@ -10,7 +10,7 @@ module ForemanBootdisk
     isolate_namespace ForemanBootdisk
 
     config.autoload_paths += Dir["#{config.root}/app/controllers/concerns"]
-    config.autoload_paths += Dir["#{config.root}/app/helpers/concerns"]
+    config.autoload_paths += Dir["#{config.root}/app/helpers"]
     config.autoload_paths += Dir["#{config.root}/app/models/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/lib"]
 
@@ -26,6 +26,12 @@ module ForemanBootdisk
 
     initializer 'foreman_bootdisk.apipie' do
       Apipie.configuration.checksum_path += ['/bootdisk/api/']
+    end
+
+    # Temporary workaround fix for helpers
+    initializer 'foreman_bootdisk.rails_loading_workaround' do
+      HostsHelper.prepend ForemanBootdisk::HostsHelperExt
+      SubnetsHelper.include ForemanBootdisk::SubnetsHelperExt
     end
 
     initializer 'foreman_bootdisk.register_plugin', before: :finisher_hook do |_app|
@@ -137,12 +143,6 @@ module ForemanBootdisk
       locale_dir = File.join(File.expand_path('../..', __dir__), 'locale')
       locale_domain = 'foreman_bootdisk'
       Foreman::Gettext::Support.add_text_domain locale_domain, locale_dir
-    end
-
-    # Temporary workaround fix for helpers
-    initializer 'foreman_bootdisk.rails_loading_workaround' do
-      HostsHelper.prepend ForemanBootdisk::HostsHelperExt
-      SubnetsHelper.prepend ForemanBootdisk::SubnetsHelperExt
     end
 
     config.to_prepare do

--- a/test/functional/foreman_bootdisk/api/v2/disks_controller_test.rb
+++ b/test/functional/foreman_bootdisk/api/v2/disks_controller_test.rb
@@ -74,9 +74,9 @@ class ForemanBootdisk::Api::V2::DisksControllerTest < ActionController::TestCase
 
     test 'path - /api/hosts/:host_id routes to #host' do
       expected_path = if Rails::VERSION::MAJOR >= 5
-                        "/api/v2/hosts/#{@host.id}"
+                        "/api/v2/bootdisk/hosts/#{@host.id}"
                       else
-                        "/api/hosts/#{@host.id}"
+                        "/api/bootdisk/hosts/#{@host.id}"
                       end
       assert_routing expected_path,
                      format: 'json',
@@ -87,7 +87,7 @@ class ForemanBootdisk::Api::V2::DisksControllerTest < ActionController::TestCase
     end
 
     test 'path - /api/generic routes to #generic' do
-      assert_routing '/api/generic',
+      assert_routing '/api/bootdisk/generic',
                      format: 'json',
                      apiv: 'v2',
                      controller: 'foreman_bootdisk/api/v2/disks',


### PR DESCRIPTION
Fixed issues:
* Generate `generic`, `host` & `subnet` image
* "Boot disk" button helper on `/subnets` page

**How to test**

Generating iso via API:
```
hammer -r bootdisk generic --file /tmp/bootdisk_test.iso
hammer -r bootdisk host --host <host> --file /tmp/bootdisk_test.iso
hammer bootdisk subnet --subnet <subnet> --file /tmp/subnet.iso
```

In UI: on host detail and on subnets page