### PR TITLE
Fixes #35794 - change bootdisk_allowed_types type to array

### DIFF
--- a/lib/foreman_bootdisk/engine.rb
+++ b/lib/foreman_bootdisk/engine.rb
@@ -124,7 +124,7 @@ module ForemanBootdisk
               description: N_("Installation media files will be cached for full host images")
 
             setting "bootdisk_allowed_types",
-              type: :string,
+              type: :array,
               default: Setting::Bootdisk.bootdisk_types,
               full_name: N_("Allowed bootdisk types"),
               description: N_("List of allowed bootdisk types, remove type to disable it")


### PR DESCRIPTION
The setting value shows up as "subnetfull_host" whereas if we edit the value, we will be able to see that it is set as "subnet,full_host"

(cherry picked from commit 7c75d4da007628d840cac051f8601c9e395fc838)