### PR TITLE
changed efiboot.img zo 6 MB size due to missing space after grubx64.e…

### DIFF
--- a/app/services/foreman_bootdisk/iso_generator.rb
+++ b/app/services/foreman_bootdisk/iso_generator.rb
@@ -125,7 +125,7 @@ module ForemanBootdisk
           f.write(opts[:grub])
         end
         efibootimg = File.join(wd, 'build', 'efiboot.img')
-        system_or_exception("truncate -s 4M #{efibootimg}", N_('Creating new image failed, install truncate utility'))
+        system_or_exception("truncate -s 6M #{efibootimg}", N_('Creating new image failed, install truncate utility'))
         system_or_exception("mkfs.msdos #{efibootimg}", N_('Failed to format the ESP image via mkfs.msdos'))
         system_or_exception("mmd -i #{efibootimg} '::/EFI'", N_('Failed to create a directory within the ESP image'))
         system_or_exception("mmd -i #{efibootimg} '::/EFI/BOOT'", N_('Failed to create a directory within the ESP image'))


### PR DESCRIPTION
Greeting,

after syslinux Package updates on Debian 11 the 4 MB size for the efiboot.img was to small and failed by adding the shimx64.efi-file

Im not sure if this is the correct way to fix the problem, but on my installtion this worked to get the iPXE Installation running again.

Kind regard,
Max