### PR TITLE
Fixes #35888 - Full host image fails with bad request (#139)

### DIFF
--- a/app/services/foreman_bootdisk/iso_generator.rb
+++ b/app/services/foreman_bootdisk/iso_generator.rb
@@ -217,7 +217,7 @@ module ForemanBootdisk
           else
             http_object = Net::HTTP
           end
-          http_object.start(uri.host, uri.port) do |http|
+          http_object.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
             request = Net::HTTP::Get.new(uri.request_uri, 'Accept-Encoding' => 'plain')
 
             http.request(request) do |response|


### PR DESCRIPTION
Enable https connection when uri scheme is https

(cherry picked from commit 7ff3112dd29198408961618ab8604bc01c912892)