### PR TITLE
refs #37792 - :template_name in correct scope

### DIFF
--- a/app/lib/foreman_bootdisk/scope/bootdisk.rb
+++ b/app/lib/foreman_bootdisk/scope/bootdisk.rb
@@ -3,6 +3,9 @@
 module ForemanBootdisk
   module Scope
     class Bootdisk < ::Foreman::Renderer::Scope::Provisioning
+      def template_name
+        "Foreman Bootdisk"
+      end
     end
   end
 end

--- a/app/lib/foreman_bootdisk/template_helpers.rb
+++ b/app/lib/foreman_bootdisk/template_helpers.rb
@@ -40,9 +40,5 @@ module ForemanBootdisk
     def bootdisk_raise(*args)
       raise ::Foreman::Exception.new(*args)
     end
-
-    def template_name
-      "Foreman Bootdisk"
-    end
   end
 end


### PR DESCRIPTION
The template_name method must be under the Bootdisk scope; otherwise,
it overrides the method from Foreman and all templates (like Grub2 or Kickstart PXE)
have name ForemanBootdisk.

How to reproduce:
* Do not apply this patch
* Pull the latest bootdisk `master`
* Provision host (with kickstart PXE or Grub)
* See the rendered template
 