### PR TITLE
Add mmx64.efi file to generated bootdisk

### DIFF
--- a/app/services/foreman_bootdisk/iso_generator.rb
+++ b/app/services/foreman_bootdisk/iso_generator.rb
@@ -133,6 +133,7 @@ module ForemanBootdisk
           File.join(wd, 'build', 'grub-hdd.cfg').to_s => 'GRUB.CFG',
           File.join(Setting[:bootdisk_grub2_dir], 'grubx64.efi').to_s => 'GRUBX64.EFI',
           File.join(Setting[:bootdisk_grub2_dir], 'shimx64.efi').to_s => 'BOOTX64.EFI',
+          File.join(Setting[:bootdisk_grub2_dir], 'mmx64.efi').to_s => 'MMX64.EFI',
         }.each do |src, dest|
           raise(Foreman::Exception.new(N_('Ensure %{file} is readable (or update "Grub2 directory" setting)'), file: src)) unless File.exist?(src)
           raise(Foreman::Exception.new(N_('Unable to mcopy %{file}'), file: src)) unless system("mcopy -m -i #{efibootimg} '#{src}' '#{"::/EFI/BOOT/#{dest}"}'")


### PR DESCRIPTION
Bootdisks generated by Foreman don't include the mmx64.efi file.
Under certain circumstances, it may be necessary to boot the system for provisioning.

Upstream installer: https://github.com/theforeman/puppet-foreman_proxy/pull/865
Downstream: https://github.com/theforeman/foreman-packaging/pull/12095