### PR TITLE
Remove message about clearing cache

### DIFF
--- a/app/services/foreman_bootdisk/iso_generator.rb
+++ b/app/services/foreman_bootdisk/iso_generator.rb
@@ -205,7 +205,7 @@ module ForemanBootdisk
         file.binmode
 
         if use_cache && !(contents = Rails.cache.fetch(uri, raw: true)).nil?
-          ForemanBootdisk.logger.info("Retrieved #{uri} from local cache (use foreman-rake tmp:cache:clear to empty)")
+          ForemanBootdisk.logger.info("Retrieved #{uri} from local cache")
           file.write(contents)
         else
           ForemanBootdisk.logger.info("Fetching #{uri}")


### PR DESCRIPTION
The command foreman-rake tmp:cache:clear only works for local files but Foreman's default deployment switched to Redis for caching. This removes the misleading part.