### PR TITLE
Replace SSH with Proxmox Upload API for bootdisk ISO uploads

### DIFF
--- a/app/models/concerns/foreman_bootdisk/compute_resources/proxmox.rb
+++ b/app/models/concerns/foreman_bootdisk/compute_resources/proxmox.rb
@@ -9,31 +9,34 @@ module ForemanBootdisk
         super + [:bootdisk]
       end
 
-      def iso_upload(iso, vm_uuid)
+      def iso_upload(iso, vm_uuid, storage_id: nil)
         server = find_vm_by_uuid(vm_uuid)
-        server.ssh_options = { password: fog_credentials[:proxmox_password] }
-        server.ssh_ip_address = proxmox_host
-        server.username = client.credentials[:current_user].split('@').first
-        server.scp_upload(iso, '/var/lib/vz/template/iso/')
-        server.reload
-        storage = storages(server.node_id, 'iso')[0]
-        storage.volumes.any? { |v| v.volid.include? File.basename(iso) }
+        upload_iso(server.node_id, storage_id, iso)
       end
 
       def iso_delete(iso, vm_uuid)
         server = find_vm_by_uuid(vm_uuid)
+        filename = File.basename(iso)
 
-        # delete the iso file from proxmox server
-        storage = storages(server.node_id, 'iso')[0]
-        volume = storage.volumes.detect { |v| v.volid.include? File.basename(iso) }
-        volume&.destroy
+        volumes = storages(server.node_id, 'iso').filter_map do |storage|
+          storage.volumes.find { |volume| File.basename(volume.volid) == filename }
+        end
+
+        if volumes.many?
+          raise ::Foreman::Exception,
+                format(_('Found multiple ISO images named %{iso}'), iso: filename)
+        end
+
+        volumes.first&.destroy
       end
 
-      def iso_attach(iso, vm_uuid)
+      def iso_attach(iso, vm_uuid, storage_id: nil)
         server = find_vm_by_uuid(vm_uuid)
-        storage = storages(server.node_id, 'iso')[0]
-        volume = storage.volumes.detect { |v| v.volid.include? File.basename(iso) }
-        disks = server.disks.map { |disk| disk.split(":")[0] }.join(";")
+        storage = storages(server.node_id, 'iso').find { |candidate| candidate.identity == storage_id }
+        volume = storage&.volumes&.detect { |v| v.volid.include? File.basename(iso) }
+        raise ::Foreman::Exception, format(_('Could not find ISO %{iso} on storage %{storage}'), iso: File.basename(iso), storage: storage_id) unless volume
+
+        disks = server.disks.map { |disk| disk.split(':')[0] }.join(';')
         server.update({ ide2: "#{volume.volid},media=cdrom" })
         server.update({ boot: "order=ide2;#{disks}" })
       end

--- a/app/models/concerns/foreman_bootdisk/compute_resources/vmware.rb
+++ b/app/models/concerns/foreman_bootdisk/compute_resources/vmware.rb
@@ -21,7 +21,7 @@ module ForemanBootdisk
         find_vm_by_uuid(vm_uuid).volumes.first.datastore
       end
 
-      def iso_upload(iso, vm_uuid)
+      def iso_upload(iso, vm_uuid, **_options)
         options = {
           'local_path' => iso,
           'datacenter' => dc.name,
@@ -41,7 +41,7 @@ module ForemanBootdisk
         client.destroy_iso options
       end
 
-      def iso_attach(iso, vm_uuid)
+      def iso_attach(iso, vm_uuid, **_options)
         controller = controller_config(vm_uuid)
         options = {
           'instance_uuid' => vm_uuid,

--- a/app/models/concerns/foreman_bootdisk/orchestration/compute.rb
+++ b/app/models/concerns/foreman_bootdisk/orchestration/compute.rb
@@ -58,7 +58,7 @@ module ForemanBootdisk
       end
 
       def bootdisk_upload_iso
-        compute_resource.iso_upload(bootdisk_isofile, uuid)
+        compute_resource.iso_upload(bootdisk_isofile, uuid, storage_id: bootdisk_iso_upload_storage)
       end
 
       def bootdisk_delete_iso
@@ -66,11 +66,15 @@ module ForemanBootdisk
       end
 
       def bootdisk_attach_iso
-        compute_resource.iso_attach(File.basename(bootdisk_isofile), uuid)
+        compute_resource.iso_attach(File.basename(bootdisk_isofile), uuid, storage_id: bootdisk_iso_upload_storage)
       end
 
       def bootdisk_detach_iso
         compute_resource.iso_detach(uuid)
+      end
+
+      def bootdisk_iso_upload_storage
+        compute_attributes&.with_indifferent_access&.dig(:iso_upload_storage)
       end
 
       def setGenerateIsoImage

--- a/test/unit/concerns/compute_resources/proxmox_test.rb
+++ b/test/unit/concerns/compute_resources/proxmox_test.rb
@@ -15,5 +15,111 @@ module ForemanBootdisk
         assert_includes @cr.capabilities, :bootdisk
       end
     end
+
+    describe '#iso_upload' do
+      setup do
+        skip unless ForemanBootdisk.with_proxmox?
+        @cr = FactoryBot.build(:proxmox_cr)
+      end
+
+      test 'uploads the ISO to the selected storage on the VM node' do
+        server = stub(node_id: 'node-1')
+        @cr.stubs(:find_vm_by_uuid).with('vm-uuid').returns(server)
+        @cr.expects(:upload_iso).with('node-1', 'iso-storage', '/tmp/host.iso').once
+
+        @cr.iso_upload('/tmp/host.iso', 'vm-uuid', storage_id: 'iso-storage')
+      end
+    end
+
+    describe '#iso_attach' do
+      setup do
+        skip unless ForemanBootdisk.with_proxmox?
+        @cr = FactoryBot.build(:proxmox_cr)
+        @server = stub(node_id: 'node-1', disks: ['scsi0: local-lvm:vm-100-disk-0', 'net0: virtio=00:11:22:33:44:55'])
+        @cr.stubs(:find_vm_by_uuid).with('vm-uuid').returns(@server)
+      end
+
+      test 'attaches the ISO from the selected storage' do
+        other_storage = stub(identity: 'other-storage')
+        volume = stub(volid: 'iso-storage:iso/host.iso')
+        selected_storage = stub(identity: 'iso-storage', volumes: [volume])
+        @cr.stubs(:storages).with('node-1', 'iso').returns([other_storage, selected_storage])
+        @server.expects(:update).with({ ide2: 'iso-storage:iso/host.iso,media=cdrom' }).once
+        @server.expects(:update).with({ boot: 'order=ide2;scsi0;net0' }).once
+
+        @cr.iso_attach('host.iso', 'vm-uuid', storage_id: 'iso-storage')
+      end
+
+      test 'raises and does not update the VM when the selected storage does not exist' do
+        storage = stub(identity: 'other-storage')
+        @cr.stubs(:storages).with('node-1', 'iso').returns([storage])
+        @server.expects(:update).never
+
+        error = assert_raises(::Foreman::Exception) do
+          @cr.iso_attach('host.iso', 'vm-uuid', storage_id: 'iso-storage')
+        end
+
+        assert_includes error.message, 'Could not find ISO host.iso on storage iso-storage'
+      end
+
+      test 'raises and does not update the VM when the ISO does not exist on the selected storage' do
+        volume = stub(volid: 'iso-storage:iso/other.iso')
+        storage = stub(identity: 'iso-storage', volumes: [volume])
+        @cr.stubs(:storages).with('node-1', 'iso').returns([storage])
+        @server.expects(:update).never
+
+        error = assert_raises(::Foreman::Exception) do
+          @cr.iso_attach('host.iso', 'vm-uuid', storage_id: 'iso-storage')
+        end
+
+        assert_includes error.message, 'Could not find ISO host.iso on storage iso-storage'
+      end
+    end
+
+    describe '#iso_delete' do
+      setup do
+        skip unless ForemanBootdisk.with_proxmox?
+        @cr = FactoryBot.build(:proxmox_cr)
+        @server = stub(node_id: 'node-1')
+        @cr.stubs(:find_vm_by_uuid).with('vm-uuid').returns(@server)
+      end
+
+      test 'deletes the matching ISO from any ISO storage' do
+        other_volume = stub(volid: 'local:iso/other.iso')
+        matching_volume = stub(volid: 'iso-storage:iso/host.iso')
+        other_storage = stub(volumes: [other_volume])
+        matching_storage = stub(volumes: [matching_volume])
+        @cr.stubs(:storages).with('node-1', 'iso').returns([other_storage, matching_storage])
+        other_volume.expects(:destroy).never
+        matching_volume.expects(:destroy).once
+
+        @cr.iso_delete('/tmp/host.iso', 'vm-uuid')
+      end
+
+      test 'does nothing when the ISO does not exist' do
+        volume = stub(volid: 'local:iso/other.iso')
+        storage = stub(volumes: [volume])
+        @cr.stubs(:storages).with('node-1', 'iso').returns([storage])
+        volume.expects(:destroy).never
+
+        assert_nil @cr.iso_delete('/tmp/host.iso', 'vm-uuid')
+      end
+
+      test 'raises and does not delete when the ISO exists on multiple storages' do
+        first_volume = stub(volid: 'local:iso/host.iso')
+        second_volume = stub(volid: 'iso-storage:iso/host.iso')
+        first_storage = stub(volumes: [first_volume])
+        second_storage = stub(volumes: [second_volume])
+        @cr.stubs(:storages).with('node-1', 'iso').returns([first_storage, second_storage])
+        first_volume.expects(:destroy).never
+        second_volume.expects(:destroy).never
+
+        error = assert_raises(::Foreman::Exception) do
+          @cr.iso_delete('/tmp/host.iso', 'vm-uuid')
+        end
+
+        assert_includes error.message, 'Found multiple ISO images named host.iso'
+      end
+    end
   end
 end

--- a/test/unit/concerns/orchestration/proxmox_compute_test.rb
+++ b/test/unit/concerns/orchestration/proxmox_compute_test.rb
@@ -13,13 +13,32 @@ module ForemanBootdisk
                                        provision_method: 'bootdisk')
     end
 
+    test 'returns selected iso upload storage from compute attributes' do
+      @proxmox_host.compute_attributes = { 'iso_upload_storage' => 'iso-storage' }
+
+      assert_equal 'iso-storage', @proxmox_host.send(:bootdisk_iso_upload_storage)
+    end
+
+    test 'iso upload storage is unavailable while deleting' do
+      @proxmox_host.compute_attributes = { 'iso_upload_storage' => 'iso-storage' }
+      @proxmox_host.save!
+
+      host = Host::Managed.find(@proxmox_host.id)
+      host.compute_resource.expects(:iso_delete).with(anything, anything)
+
+      assert_nil host.send(:bootdisk_iso_upload_storage)
+      host.send(:setDeleteIsoImage)
+    end
+
     test 'provisioning a host with provision method bootdisk in proxmox should upload iso' do
-      @proxmox_cr.expects(:iso_upload)
+      @proxmox_host.compute_attributes = { 'iso_upload_storage' => 'iso-storage' }
+      @proxmox_cr.expects(:iso_upload).with(anything, anything, storage_id: 'iso-storage')
       @proxmox_host.send(:setIsoImage)
     end
 
     test 'provisioning a host with provision method bootdisk in proxmox should attach iso' do
-      @proxmox_cr.expects(:iso_attach)
+      @proxmox_host.compute_attributes = { 'iso_upload_storage' => 'iso-storage' }
+      @proxmox_cr.expects(:iso_attach).with(anything, anything, storage_id: 'iso-storage')
       @proxmox_host.send(:setAttachIsoImage)
     end
 


### PR DESCRIPTION
- Replaced the SSH based  bootdisk ISO upload with the Proxmox Upload API.
- Updated iso_upload and iso_attach to accept and use the ISO Upload Storage selected by the user.
- Updated iso_delete to search all ISO-capable storages instead of using the first available ISO storage, which can be problematic when multiple ISO-capable storages exist. This is necessary because the selected storage_id is no longer available when the host is reloaded after provisioning.
- Added unit tests to cover the changes.


This PR depends on => https://github.com/theforeman/foreman_fog_proxmox/pull/543